### PR TITLE
💚 Fix auto-API generation in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,6 @@ sys.path[:0] = [str(HERE)]
 from lamin_sphinx import *  # noqa
 import bionty  # noqa
 
-for generated in HERE.glob("bionty.*.rst"):
-    generated.unlink()
-
 project = "Bionty"
 html_title = f"{bionty} | Lamin Labs"
 release = bionty.__version__


### PR DESCRIPTION
`autodoc` (or `autosummary`) seems to still rely on `.rst` files in some form.

Adding `rst` as a source format makes the API build again. This is not the ultimate fix, we'll investigate more how to work entirely based on md.