### PR TITLE
:green_heart: Fix notebook output capture in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,3 +14,5 @@ html_sidebars = {
     "*": ["sidebar-nav-bs"],
     "**/*": ["sidebar-nav-bs"],
 }
+
+nb_execution_mode = "force"

--- a/docs/guides/quickstart.ipynb
+++ b/docs/guides/quickstart.ipynb
@@ -13,7 +13,10 @@
    "source": [
     "In this notebook, we'll introduce the API that defines entities species, genes, and proteins.\n",
     "\n",
-    "It shows how to query different semantic representations based on underlying ontologies and how to standardize columns in `DataFrame` objects."
+    "It shows how to \n",
+    "\n",
+    "- query different semantic representations based on underlying ontologies\n",
+    "- standardize columns in `DataFrame` objects"
    ]
   },
   {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,9 @@
 # Bionty: Manage biological entities
 
-- An unambiguous intuitive API for interacting with biological entities, based on scientific community standards.
-- A reference for making data science workflows and data stores a lot more robust, for instance, using [lamindb](https://lamin.ai/lamindb).
-
 Never worry again whether a gene, a protein, a system, a perturbagen, etc. in a piece of data is in fact the thing you think it is!
 
+- An unambiguous intuitive API for interacting with biological entities, based on scientific community standards.
+- A reference for making data science workflows and data stores a lot more robust, for instance, using [lamindb](https://lamin.ai/lamindb).
 - Directly standardize `DataFrame` and `AnnData` objects and their on-disk representations against entities.
 - Enable collaborative & machine learning at scale through employing a universal programmatic standard.
 


### PR DESCRIPTION
While the notebook seems to run through during `pytest --nbmake`, there doesn't seem to be meaningful output captured!

As a consequence, the rendered guide only shows input cells and no results! I don't know why and since when that is. 😒 

Here, we temporarily fix the output capture by rerunning notebooks during docs build again!