### PR TITLE
💚 Fix docs build warnings/errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ docs/generated/*
 # data and notes files
 **/data/
 **/notes/
+docs/bionty.*

--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -13,7 +13,6 @@ This is the complete API reference:
    Disease
    Gene
    Protein
-   Taxon
    Tissue
 
 Entity collections:

--- a/bionty/_ontology.py
+++ b/bionty/_ontology.py
@@ -31,7 +31,7 @@ class Ontology:
 
     @cached_property
     def onto_dict(self) -> dict:
-        """Dict of name:label."""
+        """Keyed by name, valued by label."""
         return {i.name: i.label[0] for i in self.onto.classes()}
 
     @cached_property

--- a/bionty/gene/_core.py
+++ b/bionty/gene/_core.py
@@ -67,10 +67,11 @@ class Gene:
             data: A list of gene symbols to be standardized
                 If dataframe, will take the index
             id_type: Default is to consider input as gene symbols and alias
-            new_index
+            new_index:
                 If True, set the standardized symbols as the index
                     - unmapped will remain the original index
                     - original index stored in the `index_orig` column
+
                 If False, write to the `standardized_symbol` column
 
         Returns:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Get started by browsing a [quickstart](guides/quickstart) that walks you through
 
 For more information:
 
-- Check out the [guides](guides).
+- Check out the [guides](guides/index).
 - Browse the full [API reference](api).
 
 ```{toctree}

--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -5,6 +5,5 @@
 :glob:
 :reversed:
 
-2022-05-29-ensembl-gene-ids
-2022-05-30-ontology-managers
+*
 ```


### PR DESCRIPTION
Given we just fixed autosummary through templating, let us now be nitpicky about the docs generation so that we don't deploy docs with broken links! See: https://github.com/laminlabs/lndocs/commit/208d1d7e1bb9c795216fa230cf6ed8f8c26c71db

The last problems with building the docs were then fixed via: https://github.com/laminlabs/lndocs/commit/210dc5fedcd5e9d78c9aa744c1c9554311ff28d0