### PR TITLE
✨ Added MGI for mouse genes, switched to use feather for HGNC

### DIFF
--- a/bionty/_normalize.py
+++ b/bionty/_normalize.py
@@ -6,6 +6,8 @@ GENE_COLUMNS = {
     "ensembl_gene_id": "ensembl.gene_id",
     "entrezgene_id": "entrez.gene_id",
     "entrez_id": "entrez.gene_id",
+    "MGI Marker Accession ID": "mgi_id",
+    "Marker Symbol": "mgi_symbol",
 }
 
 

--- a/bionty/gene/_core.py
+++ b/bionty/gene/_core.py
@@ -15,8 +15,8 @@ class Gene(Table):
     """Gene.
 
     Args:
-        id: If `None`, chooses an id field in a species dependent way.
         species: `common_name` of `Species` entity table.
+        id: If `None`, chooses an id field in a species dependent way.
 
     Notes:
         Biotypes: https://useast.ensembl.org/info/genome/genebuild/biotypes.html

--- a/bionty/gene/_core.py
+++ b/bionty/gene/_core.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from functools import cached_property
-from typing import Literal
 
 import pandas as pd
 
@@ -8,11 +7,7 @@ from .._normalize import NormalizeColumns
 from .._settings import check_datasetdir_exists, settings
 from .._table import Table
 
-_IDs = Literal["ensembl.gene_id", "entrez.gene_id"]
-
-
 STD_ID_DICT = {"human": "hgnc_symbol", "mouse": "mgi_symbol"}
-ATTR_DICT = {"human": ["hgnc_id", "hgnc_symbol"], "mouse": ["mgi_symbol"]}
 FILENAMES = {"human": "hgnc_complete_set.feather", "mouse": "mgi_complete_set.feather"}
 
 

--- a/bionty/gene/_core.py
+++ b/bionty/gene/_core.py
@@ -9,11 +9,11 @@ from .._settings import check_datasetdir_exists, settings
 from .._table import Table
 
 _IDs = Literal["ensembl.gene_id", "entrez.gene_id"]
-_HGNC = "https://bionty-assets.s3.amazonaws.com/hgnc_complete_set.txt"
 
 
 STD_ID_DICT = {"human": "hgnc_symbol", "mouse": "mgi_symbol"}
 ATTR_DICT = {"human": ["hgnc_id", "hgnc_symbol"], "mouse": ["mgi_symbol"]}
+FILENAMES = {"human": "hgnc_complete_set.feather", "mouse": "mgi_complete_set.feather"}
 
 
 class Gene(Table):
@@ -29,22 +29,36 @@ class Gene(Table):
 
     """
 
-    def __init__(self, id=None, species="human"):
+    def __init__(
+        self,
+        species="human",
+        id=None,
+    ):
         self._species = species
         self._id_field = STD_ID_DICT[species]
+        self._filepath = settings.datasetdir / FILENAMES[species]
 
     @property
     def species(self):
         """The `common_name` of `Species` entity table."""
         return self._species
 
+    @property
+    def filepath(self):
+        """The local filepath to the DataFrame."""
+        return self._filepath
+
     @cached_property
     def df(self):
         """DataFrame."""
-        if self._species == "human":
-            return self._hgnc()
-        else:
+        if self.species not in {"human", "mouse"}:
             raise NotImplementedError
+        else:
+            if not self.filepath.exists():
+                self._download_df()
+            df = pd.read_feather(self.filepath)
+            NormalizeColumns.gene(df, species=self.species)
+            return df.set_index(self._id_field)
 
     @cached_property
     def lookup(self):
@@ -53,26 +67,10 @@ class Gene(Table):
         return namedtuple("id", values)
 
     @check_datasetdir_exists
-    def _hgnc(self):
-        """HGNC symbol from the HUGO Gene Nomenclature Committee."""
-        assert self.species == "human"
+    def _download_df(self):
+        from urllib.request import urlretrieve
 
-        filepath = settings.datasetdir / "hgnc_complete_set.txt"
-        if not filepath.exists():
-            print("retrieving HUGO complete gene set from EBI")
-            from urllib.request import urlretrieve
-
-            urlretrieve(_HGNC, filepath)
-        df = pd.read_csv(
-            filepath,
-            sep="\t",
-            index_col=0,
-            low_memory=False,  # If True, gets DtypeWarning
-            verbose=False,
+        urlretrieve(
+            f"https://bionty-assets.s3.amazonaws.com/{FILENAMES[self.species]}",
+            self.filepath,
         )
-        df = df.reset_index().copy()
-        NormalizeColumns.gene(df, species=self.species)
-
-        df = df.set_index("hgnc_symbol")
-
-        return df

--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -37,8 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import bionty as bt\n",
-    "import pandas as pd"
+    "import bionty as bt"
    ]
   },
   {
@@ -200,6 +199,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gene = bt.Gene(\"mouse\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gene.df"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -233,8 +250,11 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "ae1fefc8646a06dd2e75004cd934adda7c5727b046986a772e3b44b0ffba9754"
+  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.13 ('py39')",
    "language": "python",
    "name": "python3"
   },
@@ -248,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
- Switched from `hgnc_complete_set.txt` to `hgnc_complete_set.feather` and pulls from s3.
- Added MGI table for the mouse geneset.

See HGNC, MGI genesets ingestion here: https://github.com/laminlabs/bionty-assets/pull/5