### PR TITLE
💥 Redefine `lookup` in `EntityTable`

### DIFF
--- a/bionty/_cellmarker/_core.py
+++ b/bionty/_cellmarker/_core.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from functools import cached_property
 
 import pandas as pd
@@ -49,14 +48,6 @@ class CellMarker(EntityTable):
             df = df.reset_index().copy()
         df = df[~df[self._id_field].isnull()]
         return df.set_index(self._id_field)
-
-    @cached_property
-    def lookup(self):
-        """Lookup object for auto-complete."""
-        values = self.todict(self.df.index.values)
-        nt = namedtuple(self._id_field, values.keys())
-
-        return nt(**values)
 
     @check_datasetdir_exists
     def _download_df(self):

--- a/bionty/_gene/_core.py
+++ b/bionty/_gene/_core.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from functools import cached_property
 
 import pandas as pd
@@ -63,14 +62,6 @@ class Gene(EntityTable):
             df = df.reset_index().copy()
         df = df[~df[self._id_field].isnull()]
         return df.set_index(self._id_field)
-
-    @cached_property
-    def lookup(self):
-        """Lookup object for auto-complete."""
-        values = self.todict(self.df.index.values)
-        nt = namedtuple(self._id_field, values.keys())
-
-        return nt(**values)
 
     @check_datasetdir_exists
     def _download_df(self):

--- a/bionty/_gene/_core.py
+++ b/bionty/_gene/_core.py
@@ -40,6 +40,7 @@ class Gene(EntityTable):
         self._species = species
         self._filepath = settings.datasetdir / FILENAMES.get(self.species)
         self._id_field = "ensembl_gene_id" if id is None else id
+        self._lookup_col = "symbol"
 
     @property
     def species(self):

--- a/bionty/_protein/_core.py
+++ b/bionty/_protein/_core.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from functools import cached_property
 
 import pandas as pd
@@ -74,14 +73,6 @@ class Protein(EntityTable):
             df = df.reset_index().copy()
         df = df[~df[self._id_field].isnull()]
         return df.set_index(self._id_field)
-
-    @cached_property
-    def lookup(self):
-        """Lookup object for auto-complete."""
-        values = self.todict(self.df.index.values)
-        nt = namedtuple(self._id_field, values.keys())
-
-        return nt(**values)
 
     @check_datasetdir_exists
     def _download_df(self):

--- a/bionty/_species/_core.py
+++ b/bionty/_species/_core.py
@@ -20,6 +20,7 @@ class Species(EntityTable):
     def __init__(self, id=None):
         super().__init__(id=id)
         self._id_field = "common_name" if id is None else id
+        self._lookup_col = "common_name"
 
     @cached_property
     def df(self) -> pd.DataFrame:

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -42,6 +42,7 @@ class EntityTable:
 
     @property
     def lookup_col(self) -> str:
+        """The column that allows auto-completion."""
         return self._lookup_col
 
     @lookup_col.setter
@@ -50,7 +51,12 @@ class EntityTable:
 
     @cached_property
     def lookup(self) -> NamedTuple:
-        """Return an auto-complete object for the bionty id."""
+        """Return an auto-complete object for the bionty id.
+
+        By default lookup allows auto-completion for name and returns the id.
+            lookup column can be changed using `.lookup_col = `
+            id is specified during init.
+        """
         df = self.df.reset_index()
         if self._lookup_col not in df:
             raise AssertionError(f"No {self._lookup_col} column exists!")

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -1,6 +1,7 @@
 import re
 from collections import namedtuple
 from functools import cached_property
+from typing import Iterable, NamedTuple
 
 import pandas as pd
 
@@ -27,37 +28,67 @@ class EntityTable:
     def __init__(self, id=None):
         self._id_field = "id" if id is None else id
         self._Ontology = Ontology
+        self._lookup_col = "name"
 
     @cached_property
-    def entity(self):
+    def entity(self) -> str:
         """Name of the entity."""
         return _camel_to_snake(self.__class__.__name__)
 
     @cached_property
-    def df(self):
+    def df(self) -> pd.DataFrame:
         """DataFrame representation of EntityTable."""
         raise NotImplementedError
 
-    @cached_property
-    def lookup(self):
-        """Return an auto-complete object for the bionty id."""
-        values = self.todict(self.df.index.to_list())
-        nt = namedtuple(self._id_field, values.keys())
+    @property
+    def lookup_col(self) -> str:
+        return self._lookup_col
 
-        return nt(**values)
+    @lookup_col.setter
+    def lookup_col(self, column_name) -> None:
+        self._lookup_col = column_name
+
+    @cached_property
+    def lookup(self) -> NamedTuple:
+        """Return an auto-complete object for the bionty id."""
+        df = self.df.reset_index()
+        if self._lookup_col not in df:
+            raise AssertionError(f"No {self._lookup_col} column exists!")
+
+        df.index = self._uniquefy_duplicates(
+            self._to_lookup_keys(df[self._lookup_col].values)
+        )
+        df_nt = {}
+        for k, v in df.to_dict(orient="index").items():
+            df_nt[k] = self._namedtuple_from_dict(v)
+        return self._namedtuple_from_dict(df_nt)
 
     @cached_property
     def ontology(self):
         """Ontology."""
         raise NotImplementedError
 
-    def todict(self, x: list) -> dict:
+    def _to_lookup_keys(self, x: list) -> list:
         """Convert a list of strings to tab-completion allowed formats."""
-        mapper = {re.sub("[^0-9a-zA-Z]+", "_", i): i for i in x}
-        for k in list(mapper.keys()):
-            if not k[0].isalpha():
-                mapper[f"LOOKUP_{k}"] = mapper.pop(k)
-        return mapper
+        lookup = [re.sub("[^0-9a-zA-Z]+", "_", i) for i in x]
+        for i, value in enumerate(lookup):
+            if not value[0].isalpha():
+                lookup[i] = f"LOOKUP_{value}"
+        return lookup
+
+    def _namedtuple_from_dict(self, mydict: dict, name: str = "MyTuple") -> NamedTuple:
+        """Create a namedtuple from a dict to allow autocompletion."""
+        nt = namedtuple(name, mydict)  # type:ignore
+        return nt(**mydict)
+
+    def _uniquefy_duplicates(self, lst: Iterable) -> list:
+        """Uniquefy duplicated values in a list."""
+        df = pd.DataFrame(lst)
+        duplicated = df[df[0].duplicated(keep=False)]
+        df.loc[duplicated.index, 0] = duplicated[0] + duplicated.groupby(
+            0
+        ).cumcount().astype(str)
+        return list(df[0].values)
 
     def curate(
         self, df: pd.DataFrame, column: str = None, agg_col: str = None

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -52,6 +52,7 @@ class EntityTable:
     def lookup(self) -> NamedTuple:
         """Return an auto-complete object for the bionty id."""
         df = self.df.reset_index()
+        print(df.columns)
         if self._lookup_col not in df:
             raise AssertionError(f"No {self._lookup_col} column exists!")
 

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -28,6 +28,8 @@ class EntityTable:
     def __init__(self, id=None):
         self._id_field = "id" if id is None else id
         self._Ontology = Ontology
+        # By default lookup allows auto-completion for name and returns the id.
+        # lookup column can be changed using `.lookup_col = `.
         self._lookup_col = "name"
 
     @cached_property
@@ -51,19 +53,16 @@ class EntityTable:
 
     @cached_property
     def lookup(self) -> NamedTuple:
-        """Return an auto-complete object for the bionty id.
-
-        By default lookup allows auto-completion for name and returns the id.
-            lookup column can be changed using `.lookup_col = `
-            id is specified during init.
-        """
+        """Return an auto-complete object for the bionty id."""
         df = self.df.reset_index()
         if self._lookup_col not in df:
             raise AssertionError(f"No {self._lookup_col} column exists!")
 
+        # uniquefy lookup keys
         df.index = self._uniquefy_duplicates(
             self._to_lookup_keys(df[self._lookup_col].values)
         )
+
         return self._namedtuple_from_dict(df[self._id_field].to_dict())
 
     @cached_property

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -73,7 +73,7 @@ class EntityTable:
 
     def _to_lookup_keys(self, x: list) -> list:
         """Convert a list of strings to tab-completion allowed formats."""
-        lookup = [re.sub("[^0-9a-zA-Z]+", "__", str(i)) for i in x]
+        lookup = [re.sub("[^0-9a-zA-Z]+", "_", str(i)) for i in x]
         for i, value in enumerate(lookup):
             if not value[0].isalpha():
                 lookup[i] = f"LOOKUP_{value}"
@@ -89,7 +89,7 @@ class EntityTable:
         df = pd.DataFrame(lst)
         duplicated = df[df[0].duplicated(keep=False)]
         df.loc[duplicated.index, 0] = (
-            duplicated[0] + "_" + duplicated.groupby(0).cumcount().astype(str)
+            duplicated[0] + "__" + duplicated.groupby(0).cumcount().astype(str)
         )
         return list(df[0].values)
 

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -52,7 +52,6 @@ class EntityTable:
     def lookup(self) -> NamedTuple:
         """Return an auto-complete object for the bionty id."""
         df = self.df.reset_index()
-        print(df.columns)
         if self._lookup_col not in df:
             raise AssertionError(f"No {self._lookup_col} column exists!")
 

--- a/docs/guide/lookup.ipynb
+++ b/docs/guide/lookup.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gene = bt.Gene(species=\"human\", id=\"symbol\")"
+    "gene = bt.Gene(species=\"human\")"
    ]
   },
   {
@@ -162,25 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lookup.PDCD1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gene.df.loc[\"PDCD1\"].head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gene.df.index"
+    "lookup.TCF7"
    ]
   },
   {
@@ -196,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gene.df.loc[gene.df.index.isin([\"BRCA1\", \"BRCA2\"])]"
+    "gene.df.loc[gene.df[\"symbol\"].isin([\"BRCA1\", \"BRCA2\"])]"
    ]
   },
   {
@@ -253,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "protein.lookup.O60337"
+    "protein.lookup.ABC_transporter_domain_containing_protein"
    ]
   },
   {


### PR DESCRIPTION
Redefined `.lookup` in an EntityTable class:

`.lookup.{name}` returns the id specified during `init`.

`name` column is often an id field that represents interpretable semantics. It can be reset by `.lookup_col = `

For `Gene`, the name column is defaults to `symbol`.

For instance:
```
>>> gene = Gene(id='ensembl_gene_id')
>>> gene.lookup.TCF7
>>> "ENSG00000081059"
```