### PR TITLE
♻️ Refactor version files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ _docs_tmp*
 # local versions
 **/versions/_current.yaml
 **/versions/_local.yaml
+**/versions/_lndb.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,7 @@ docs/bionty.*
 _dynamic/
 *.ipynb_checkpoints/
 _docs_tmp*
-_versions.yaml
+
+# local versions
+**/versions/_current.yaml
+**/versions/_local.yaml

--- a/bionty/_sync_versions.py
+++ b/bionty/_sync_versions.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from .dev._io import load_yaml, write_yaml
@@ -6,11 +7,10 @@ ROOT = Path(__file__).parent / "versions"
 VERSIONS = ROOT / "versions.yaml"
 _LOCAL = ROOT / "_local.yaml"
 _CURRENT = ROOT / "_current.yaml"
+_DB = ROOT / "_lndb.yaml"
 
 # if _local.yaml doesn't exist, copy from versions.yaml
 if not _LOCAL.exists():
-    import shutil
-
     shutil.copy2(VERSIONS, _LOCAL)
 # adds entries in the public versions.yaml table to _local.yaml
 versions = load_yaml(VERSIONS)
@@ -39,3 +39,7 @@ if not _CURRENT.exists():
         version = str(sorted(versions.keys(), reverse=True)[0])
         _current[name] = {db: version}
     write_yaml(_current, _CURRENT)
+
+# if no _lndb file, write _current to _lndb for lndb_setup
+if not _DB.exists():
+    shutil.copy2(_CURRENT, _DB)

--- a/bionty/_sync_versions.py
+++ b/bionty/_sync_versions.py
@@ -36,6 +36,6 @@ if not _CURRENT.exists():
     for name, db_versions in versions.items():
         db = next(iter(db_versions))
         versions = db_versions.get(db).get("versions")
-        version = sorted(versions.keys(), reverse=True)[0]
+        version = str(sorted(versions.keys(), reverse=True)[0])
         _current[name] = {db: version}
     write_yaml(_current, _CURRENT)

--- a/bionty/_sync_versions.py
+++ b/bionty/_sync_versions.py
@@ -4,15 +4,38 @@ from .dev._io import load_yaml, write_yaml
 
 ROOT = Path(__file__).parent / "versions"
 VERSIONS = ROOT / "versions.yaml"
-_VERSIONS = ROOT / "_versions.yaml"
+_LOCAL = ROOT / "_local.yaml"
+_CURRENT = ROOT / "_current.yaml"
 
-# writes the most recent version to the _versions.yaml
-if not _VERSIONS.exists():
-    versions = load_yaml(VERSIONS)
-    _versions = {}
+# if _local.yaml doesn't exist, copy from versions.yaml
+if not _LOCAL.exists():
+    import shutil
+
+    shutil.copy2(VERSIONS, _LOCAL)
+# adds entries in the public versions.yaml table to _local.yaml
+versions = load_yaml(VERSIONS)
+_local = load_yaml(_LOCAL)
+
+for entity, dbs in versions.items():
+    if entity not in _local:
+        _local[entity] = versions[entity]
+    else:
+        for db_name, v in dbs.items():
+            if db_name not in _local[entity]:
+                _local[entity][db_name] = dbs[db_name]
+            else:
+                for version in v["versions"]:
+                    if version not in _local[entity][db_name]["versions"]:
+                        _local[entity][db_name]["versions"][version] = v["versions"][
+                            version
+                        ]
+
+# writes the most recent version to the _current.yaml
+if not _CURRENT.exists():
+    _current = {}
     for name, db_versions in versions.items():
         db = next(iter(db_versions))
         versions = db_versions.get(db).get("versions")
         version = sorted(versions.keys(), reverse=True)[0]
-        _versions[name] = {db: version}
-    write_yaml(_versions, _VERSIONS)
+        _current[name] = {db: version}
+    write_yaml(_current, _CURRENT)

--- a/bionty/_sync_versions.py
+++ b/bionty/_sync_versions.py
@@ -9,13 +9,15 @@ _LOCAL = ROOT / "_local.yaml"
 _CURRENT = ROOT / "_current.yaml"
 _DB = ROOT / "_lndb.yaml"
 
+versions = load_yaml(VERSIONS)
+
 # if _local.yaml doesn't exist, copy from versions.yaml
 if not _LOCAL.exists():
     shutil.copy2(VERSIONS, _LOCAL)
-# adds entries in the public versions.yaml table to _local.yaml
-versions = load_yaml(VERSIONS)
+
 _local = load_yaml(_LOCAL)
 
+# update _local to add additional entries from the public versions.yaml table
 for entity, dbs in versions.items():
     if entity not in _local:
         _local[entity] = versions[entity]

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -183,7 +183,7 @@ class EntityTable:
     def _load_current_version(self):
         """Load current version."""
         ((database, version),) = (
-            load_yaml(VERSIONS_PATH / "_versions.yaml")
+            load_yaml(VERSIONS_PATH / "_current.yaml")
             .get(self.__class__.__name__)
             .items()
         )

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -222,7 +222,7 @@ class EntityTable:
         db_versions = self._load_versions()
         # Use the latest version if version is None.
         self._database = database_ if database is None else database
-        self._version = version_ if version is None else version
+        self._version = version_ if version is None else str(version)
         self._url = db_versions.get(self._database).get("versions").get(self._version)
         if self._url is None:
             raise ValueError(

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -201,8 +201,18 @@ class EntityTable:
         return database, version
 
     def _load_versions(self):
-        """Load all versions."""
-        return load_yaml(VERSIONS_PATH / "versions.yaml").get(self.__class__.__name__)
+        """Load all versions with string version keys."""
+        versions = load_yaml(VERSIONS_PATH / "versions.yaml").get(
+            self.__class__.__name__
+        )
+
+        versions_db = {}
+
+        for db, vers in versions.items():
+            versions_db[db] = {"versions": {}}
+            for k in vers["versions"]:
+                versions_db[db]["versions"][str(k)] = versions[db]["versions"][k]
+        return versions_db
 
     def _get_version(
         self, database: Optional[str] = None, version: Optional[str] = None

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -197,6 +197,7 @@ class EntityTable:
         ((database, version),) = (
             load_yaml(VERSIONS_PATH / filename).get(self.__class__.__name__).items()
         )
+
         return database, version
 
     def _load_versions(self):

--- a/bionty/_table.py
+++ b/bionty/_table.py
@@ -182,10 +182,20 @@ class EntityTable:
 
     def _load_current_version(self):
         """Load current version."""
+        try:
+            import lndb_setup
+
+            db = lndb_setup.settings._instance_exists
+        except ImportError:
+            db = False
+
+        if db:
+            filename = "_lndb.yaml"
+        else:
+            filename = "_current.yaml"
+
         ((database, version),) = (
-            load_yaml(VERSIONS_PATH / "_current.yaml")
-            .get(self.__class__.__name__)
-            .items()
+            load_yaml(VERSIONS_PATH / filename).get(self.__class__.__name__).items()
         )
         return database, version
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ Name | PR | User | Date | Patch
 --- | --- | --- | --- | ---
 ✨ Added ontology_info | [155](https://github.com/laminlabs/bionty/pull/155) | [sunnyosun](https://github.com/sunnyosun) | 2022-12-01 |
 ✨ Add readout to lookup | [153](https://github.com/laminlabs/bionty/pull/153) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-24 | 0.5.5
-✨ Write most recent versions to `_versions.yaml` | [152](https://github.com/laminlabs/bionty/pull/152) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-23 |
+✨ Write most recent versions to `_current.yaml` | [152](https://github.com/laminlabs/bionty/pull/152) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-23 |
 🎨 Fetch the latest ontology from ols | [151](https://github.com/laminlabs/bionty/pull/151) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-22 |
 🚚 Moved readout from bioreadout into bionty | [150](https://github.com/laminlabs/bionty/pull/150) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-19 |
 ✨ Added a local versions tracking file | [149](https://github.com/laminlabs/bionty/pull/149) | [sunnyosun](https://github.com/sunnyosun) | 2022-11-18 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "nbproject",
     "cloudpathlib",
     "boto3",
+    "lndb_setup",
 ]
 
 [project.urls]


### PR DESCRIPTION
Together with:
- https://github.com/laminlabs/lndb-setup/pull/121
- https://github.com/laminlabs/lnschema-bionty/pull/35

Design doc: https://www.notion.so/laminlabs/Manage-knowledge-versioning-in-Bionty-5f7c9d3202f2472295f7934b6b32a7d8

public files:
- `versions/versions.yaml`: the public versions file, containing default db versions for each entity

local files:
- `versions/_local.yaml`: local copy of the versions file; users can add customized versions
- `versions/_current.yaml`: in-use local version of each entity
- `versions/_lndb.yaml`: version of each entity in the current instance of lamindb. 
    - If not in a lamindb instance, use `_current`. 
    - If lnschema-bionty is not mounted, use `_current`
    - If entity table is not found in lamindb instance, use `_current`