### PR TITLE
Fix #167

### DIFF
--- a/bionty/dev/_io.py
+++ b/bionty/dev/_io.py
@@ -39,7 +39,7 @@ def url_download(  # pragma: no cover
         if filename is None:
             filename = url.split("/")[-1]
 
-        with Progress(refresh_per_second=1500) as progress:
+        with Progress(refresh_per_second=10000) as progress:
             task = progress.add_task("[red]Downloading...", total=total_content_length)
 
             with open(filename, "wb") as file:


### PR DESCRIPTION
Increases the refresh rate per second for the progressbar to 10k which is frankly a lot. Should help with super quick downloads.

@Koncopd do you mind testing this? You can remove the "data" folder from your bionty installation and then import ontologies again. It should trigger a download. Ask away if it's unclear.

Signed-off-by: zethson <lukas.heumos@posteo.net>