### PR TITLE
📝 Use guide/index as landing page

### DIFF
--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -39,6 +39,13 @@ External API:
 
    Ontology
 
+Dev API:
+
+.. autosummary::
+   :toctree: .
+
+   dev
+
 """
 
 __version__ = "0.6.5"

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,5 +1,27 @@
 # Guide
 
+Welcome to bionty! 👋
+
+## Resources
+
+Lookup & curate metadata based on scientific standards.
+
+- Gene: [Ensembl](https://ensembl.org/), [NCBI Gene](https://www.ncbi.nlm.nih.gov/gene/), [HGNC](https://www.genenames.org/), [MGI](http://www.informatics.jax.org/)
+- Protein: [Uniprot](https://www.uniprot.org/)
+- Species: [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy/), [Ensembl Species](https://useast.ensembl.org/info/about/species.html)
+- Cell type: [Cell Ontology](https://obophenotype.github.io/cell-ontology/)
+- Cell marker: [CellMarker](http://xteam.xbio.top/CellMarker)
+- Tissue: [Uberon](http://obophenotype.github.io/uberon/)
+- Disease: [Mondo](https://mondo.monarchinitiative.org/)
+
+## Getting started
+
+Install:
+
+```
+pip install bionty
+```
+
 Get started with the following walk-through:
 
 - {doc}`curate`
@@ -9,6 +31,8 @@ Get started with the following walk-through:
 Explore additional entities:
 
 - {doc}`ontology`
+
+See [bionty-assets](https://lamin.ai/docs/bionty-assets) for the curation of underlying assets.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,29 +3,6 @@
 :end-line: 5
 ```
 
-Lookup & curate metadata based on scientific standards.
-
-- Gene: [Ensembl](https://ensembl.org/), [NCBI Gene](https://www.ncbi.nlm.nih.gov/gene/), [HGNC](https://www.genenames.org/), [MGI](http://www.informatics.jax.org/)
-- Protein: [Uniprot](https://www.uniprot.org/)
-- Species: [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy/), [Ensembl Species](https://useast.ensembl.org/info/about/species.html)
-- Cell type: [Cell Ontology](https://obophenotype.github.io/cell-ontology/)
-- Cell marker: [CellMarker](http://xteam.xbio.top/CellMarker)
-- Tissue: [Uberon](http://obophenotype.github.io/uberon/)
-- Disease: [Mondo](https://mondo.monarchinitiative.org/)
-
-Install:
-
-```
-pip install bionty
-```
-
-Resources:
-
-- Get started with the [guide](guide/index), or browse the [API reference](api) and [FAQ](faq/index).
-- See the [source code](https://github.com/laminlabs/bionty) on GitHub.
-- See [bionty-assets](https://lamin.ai/docs/bionty-assets) for the curation of underlying assets.
-- See the [changelog](changelog) for updates.
-
 ```{toctree}
 :maxdepth: 1
 :hidden:


### PR DESCRIPTION
- Added `dev` to the API age
- Moved the content from `docs/index` to `docs/guide/index` (the latter will be the landing page after docs integration across lamindb and lnsetup)