### PR TITLE
:memo: Add better documentation & function to print currently available/active ontologies

### DIFF
--- a/bionty/__init__.py
+++ b/bionty/__init__.py
@@ -16,6 +16,7 @@ Entities:
    CellMarker
    Tissue
    Disease
+   Phenotype
    Readout
 
 The base model for every entity class is:
@@ -24,6 +25,14 @@ The base model for every entity class is:
    :toctree: .
 
    EntityTable
+
+Display of currently available or used versions:
+
+.. autosummary::
+   :toctree: .
+
+    display_available_versions
+    display_active_versions
 
 Lookup of vocabulary:
 
@@ -73,6 +82,7 @@ from ._normalize import NormalizeColumns
 from ._table import EntityTable
 from ._ontology import Ontology
 from ._lookup import lookup
+from ._display_versions import display_active_versions, display_available_versions
 
 # dev
 from . import dev

--- a/bionty/_display_versions.py
+++ b/bionty/_display_versions.py
@@ -1,5 +1,10 @@
 from pathlib import Path
-from typing import Literal
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
 
 from rich.console import Console
 from rich.table import Table

--- a/bionty/_display_versions.py
+++ b/bionty/_display_versions.py
@@ -3,13 +3,6 @@ from pathlib import Path
 
 import lndb
 from rich import print
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore  # noqa: F401
-
-
 from rich.console import Console
 from rich.table import Table
 

--- a/bionty/_display_versions.py
+++ b/bionty/_display_versions.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Literal
 
@@ -9,10 +8,12 @@ from bionty.dev._io import load_yaml
 
 console = Console()
 
+CWD = Path.cwd()
+
 
 def display_available_versions() -> None:  # pragma: no cover
     """Displays all available entities and versions in a Rich table."""
-    VERSIONS_FILE_PATH = Path(f"{os.getcwd()}/bionty/versions/versions.yaml")
+    VERSIONS_FILE_PATH = Path(f"{CWD}/bionty/versions/versions.yaml")
     versions = load_yaml(VERSIONS_FILE_PATH.resolve())
 
     table = _generate_rich_versions_table(title="Available versions")
@@ -34,7 +35,7 @@ def display_active_versions(
     Args:
         version_table: One of '_current.yaml', '_lndb.yaml', '_local.yaml'
     """
-    VERSIONS_FILE_PATH = Path(f"{os.getcwd()}/bionty/versions/{version_table}")
+    VERSIONS_FILE_PATH = Path(f"{CWD}/bionty/versions/{version_table}")
     versions = load_yaml(VERSIONS_FILE_PATH.resolve())
 
     table = _generate_rich_versions_table(

--- a/bionty/_display_versions.py
+++ b/bionty/_display_versions.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from typing import Literal
+
+from rich.console import Console
+from rich.table import Table
+
+from bionty.dev._io import load_yaml
+
+console = Console()
+
+
+def display_available_versions() -> None:  # pragma: no cover
+    """Displays all available entities and versions in a Rich table."""
+    VERSIONS_FILE_PATH = Path(f"{os.getcwd()}/bionty/versions/versions.yaml")
+    versions = load_yaml(VERSIONS_FILE_PATH.resolve())
+
+    table = _generate_rich_versions_table(title="Available versions")
+
+    for entity, db_to_version in versions.items():
+        for db, _to_versions_url in db_to_version.items():
+            for _, version_to_url in _to_versions_url.items():
+                for version, url in version_to_url.items():
+                    table.add_row(entity, db, str(version))
+
+    console.print(table)
+
+
+def display_active_versions(
+    version_table: Literal["_current.yaml", "_lndb.yaml", "_local.yaml"]
+) -> None:  # pragma: no cover
+    """Displays all currently set as default entities and versions in a Rich table.
+
+    Args:
+        version_table: One of '_current.yaml', '_lndb.yaml', '_local.yaml'
+    """
+    VERSIONS_FILE_PATH = Path(f"{os.getcwd()}/bionty/versions/{version_table}")
+    versions = load_yaml(VERSIONS_FILE_PATH.resolve())
+
+    table = _generate_rich_versions_table(
+        title=f"Currently used versions in {version_table}"
+    )
+
+    for entity, db_to_version in versions.items():
+        for db, version in db_to_version.items():
+            table.add_row(entity, db, str(version))
+
+    console.print(table)
+
+
+def _generate_rich_versions_table(title: str) -> Table:  # pragma: no cover
+    table = Table(title=title)
+
+    table.add_column("Entity", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Database", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Version", justify="right", style="cyan", no_wrap=True)
+
+    return table

--- a/bionty/_display_versions.py
+++ b/bionty/_display_versions.py
@@ -1,9 +1,13 @@
+import os
 from pathlib import Path
+
+import lndb
+from rich import print
 
 try:
     from typing import Literal
 except ImportError:
-    from typing_extensions import Literal  # type: ignore
+    from typing_extensions import Literal  # type: ignore  # noqa: F401
 
 
 from rich.console import Console
@@ -13,12 +17,12 @@ from bionty.dev._io import load_yaml
 
 console = Console()
 
-CWD = Path.cwd()
+WD = os.path.dirname(__file__)
 
 
 def display_available_versions() -> None:  # pragma: no cover
     """Displays all available entities and versions in a Rich table."""
-    VERSIONS_FILE_PATH = Path(f"{CWD}/bionty/versions/versions.yaml")
+    VERSIONS_FILE_PATH = Path(f"{WD}/versions/_local.yaml")
     versions = load_yaml(VERSIONS_FILE_PATH.resolve())
 
     table = _generate_rich_versions_table(title="Available versions")
@@ -32,15 +36,18 @@ def display_available_versions() -> None:  # pragma: no cover
     console.print(table)
 
 
-def display_active_versions(
-    version_table: Literal["_current.yaml", "_lndb.yaml", "_local.yaml"]
-) -> None:  # pragma: no cover
-    """Displays all currently set as default entities and versions in a Rich table.
+def display_active_versions() -> None:  # pragma: no cover
+    """Displays all currently set as default entities and versions in a Rich table."""
+    version_table = "_current.yaml"
+    try:
+        if os.environ["LAMINDB_INSTANCE_LOADED"] == 1:
+            version_table = "_lndb.yaml"
+            print("[bold blue]Currently operating inside lamindb instance.")
+            print(lndb.settings.instance)
+    except KeyError:
+        pass
 
-    Args:
-        version_table: One of '_current.yaml', '_lndb.yaml', '_local.yaml'
-    """
-    VERSIONS_FILE_PATH = Path(f"{CWD}/bionty/versions/{version_table}")
+    VERSIONS_FILE_PATH = Path(f"{WD}/versions/{version_table}")
     versions = load_yaml(VERSIONS_FILE_PATH.resolve())
 
     table = _generate_rich_versions_table(

--- a/bionty/dev/__init__.py
+++ b/bionty/dev/__init__.py
@@ -4,7 +4,7 @@
    :toctree: .
 
    ontology_info
-   current_db_version
+   latest_db_version
 """
 from ._fix_index import (
     check_if_index_compliant,
@@ -13,4 +13,4 @@ from ._fix_index import (
 )  # noqa
 
 from ._ontology import ontology_info
-from ._current_db_version import current_db_version
+from ._latest_db_version import latest_db_version

--- a/bionty/dev/_latest_db_version.py
+++ b/bionty/dev/_latest_db_version.py
@@ -1,8 +1,15 @@
 import pandas as pd
 
 
-def current_db_version(db: str):
-    """Lookup the current version of a database."""
+def latest_db_version(db: str) -> str:
+    """Lookup the latest version of a database.
+
+    Args:
+        db: The database to look up the version for.
+
+    Returns:
+        The version of the database. Usually a date.
+    """
     db = db.lower()
 
     if db == "ensembl":

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,10 +4,10 @@
 
 Bionty tracks all supported and the currently active ontologies four `*.yaml` files.
 
-1. `versions.yaml`: Stores all available ontologies. Users should not edit this file.
-2. `_current.yaml`: Stores the currently active ontologies. Users should never edit this file.
-3. `_lndb.yaml`: Stores the currently active ontologies as defined by lamindb. Users should never edit this file.
-4. `_local.yaml`: Stores all locally available ontologies. Users may edit this file.
+1. `versions.yaml`: Stores all by Bionty supported ontologies. Users should not edit this file.
+2. `_local.yaml`: Stores all locally available ontologies. Users may edit this file.
+3. `_current.yaml`: Stores the currently active ontologies. Users should never edit this file.
+4. `_lndb.yaml`: Stores the currently active ontologies as defined by lamindb. Users should never edit this file.
 
 On startup, Bionty syncs these yaml files. If the user is operating in a lamindb instance,
 the versions specified in the `_lndb.yaml` will be used.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Alternatively, if Bionty is run in standalone mode, the versions specified in `_
 Users may adapt the `_local.yaml` with additional sources of ontologies that Bionty may not offer out of the box.
 
 The available and currently active ontologies can also be printed to the console with
-{func}`bionty.display_available_versions` or {func}`bt.display_active_versions`.
+{func}`bionty.display_available_versions` or {func}`bionty.display_active_versions`.
 
 ## Setting default ontologies
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,20 @@
+## Configuration
+
+### On the various yaml files
+
+Bionty tracks all supported and the currently active ontologies four `*.yaml` files.
+
+1. `versions.yaml`: Stores all available ontologies. Users should not edit this file.
+2. `_current.yaml`: Stores the currently active ontologies. Users should never edit this file.
+3. `_lndb.yaml`: Stores the currently active ontologies as defined by lamindb. Users should never edit this file.
+4. `_local.yaml`: Stores all locally available ontologies. Users may edit this file.
+
+The available and currently active ontologies can also be printed to the console with `TBD`.
+
+### Setting default ontologies
+
+TODO
+
+### Initializing bionty's defaults for all lamindb instances
+
+TODO

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,11 @@ Bionty tracks all supported and the currently active ontologies four `*.yaml` fi
 3. `_lndb.yaml`: Stores the currently active ontologies as defined by lamindb. Users should never edit this file.
 4. `_local.yaml`: Stores all locally available ontologies. Users may edit this file.
 
+On startup, Bionty syncs these yaml files. If the user is operating in a lamindb instance,
+the versions specified in the `_lndb.yaml` will be used.
+Alternatively, if Bionty is run in standalone mode, the versions specified in `_current.yaml` will be used.
+Users may adapt the `_local.yaml` with additional sources of ontologies that Bionty may not offer out of the box.
+
 The available and currently active ontologies can also be printed to the console with
 {func}`bionty.display_available_versions` or {func}`bt.display_active_versions`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-## Configuration
+# Configuration
 
-### On the various yaml files
+## On the various yaml files
 
 Bionty tracks all supported and the currently active ontologies four `*.yaml` files.
 
@@ -9,12 +9,13 @@ Bionty tracks all supported and the currently active ontologies four `*.yaml` fi
 3. `_lndb.yaml`: Stores the currently active ontologies as defined by lamindb. Users should never edit this file.
 4. `_local.yaml`: Stores all locally available ontologies. Users may edit this file.
 
-The available and currently active ontologies can also be printed to the console with `TBD`.
+The available and currently active ontologies can also be printed to the console with
+{func}`bionty.display_available_versions` or {func}`bt.display_active_versions`.
 
-### Setting default ontologies
+## Setting default ontologies
 
-TODO
+Details will be added soon.
 
-### Initializing bionty's defaults for all lamindb instances
+## Initializing bionty's defaults for all lamindb instances
 
-TODO
+Details will be added soon.

--- a/docs/guide/ontology.ipynb
+++ b/docs/guide/ontology.ipynb
@@ -22,6 +22,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fdec8739-4605-4b93-b7f4-be3d7bc22367",
+   "metadata": {},
+   "source": [
+    "All available ontologies and their versions can be printed with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35412cec-2abf-4690-a784-69c9e818f07e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bt.display_available_versions()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e33f73d-ea0a-40f8-899d-0451a7d6fc6e",
+   "metadata": {},
+   "source": [
+    "The currently used versions can be shown with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e77dfa-5c82-46fd-8955-21467a19ab09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bt.display_active_versions()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "da817e13-2102-47af-8d05-da8f1039ec47",
    "metadata": {},
    "source": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,19 @@
 :end-line: 5
 ```
 
+Bionty - Manage biological entities.
+
+Lookup & curate metadata based on scientific standards.
+
+    Access biological knowledge without the timeouts of many existing REST endpoints.
+
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
 guide/index
 api
+configuration
 faq/index
 changelog
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,12 @@
 :end-line: 5
 ```
 
-Bionty - Manage biological entities.
+Bionty allows you to:
 
-Lookup & curate metadata based on scientific standards.
+1. Lookup & curate metadata based on scientific standards.
+2. Access biological knowledge without the timeouts of many existing REST endpoints.
 
-    Access biological knowledge without the timeouts of many existing REST endpoints.
+Bionty is also fully integrated into the [lamin platform](https://lamin.ai/).
 
 ```{toctree}
 :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "lndb",
     "rich",
     "cached_property",
-    "typing_extensions"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "lndb",
     "rich",
     "cached_property",
+    "typing_extensions"
 ]
 
 [project.urls]

--- a/tests/test_current_db_version.py
+++ b/tests/test_current_db_version.py
@@ -1,6 +1,6 @@
-from bionty.dev import current_db_version
+from bionty.dev import latest_db_version
 
 
 def test_current_db_version():
-    v = current_db_version(db="ensembl")
+    v = latest_db_version(db="ensembl")
     assert v.startswith("release-")


### PR DESCRIPTION
This PR slightly improves documentation. I'll have a second round of more documentation to nail this.

```
>>> import bionty as bt
>>> bt.display_available_versions()
>>> bt.display_active_versions(table="_lndb.yaml")
```

![image](https://user-images.githubusercontent.com/21954664/219662901-003fb072-50fd-4ef0-bb95-9577644e5982.png)
