### PR TITLE
:art: Deduce filenames on the fly for non-S3 Entites

### DIFF
--- a/bionty/_celltype/_core.py
+++ b/bionty/_celltype/_core.py
@@ -2,11 +2,6 @@ from typing import Optional
 
 from .._entity import Entity
 
-FILENAMES = {
-    "human_cl_ontology": "human_cl_lookup.parquet",
-    "human_ca": "human_ca_lookup.parquet",
-}
-
 
 class CellType(Entity):
     """Cell type ontologies.
@@ -32,5 +27,4 @@ class CellType(Entity):
             database=database,
             version=version,
             species=species,
-            filenames=FILENAMES,
         )

--- a/bionty/_entity.py
+++ b/bionty/_entity.py
@@ -45,8 +45,7 @@ class Entity:
         # lookup column can be changed using `.lookup_col = `.
         self._lookup_col = "name"
         self._species = "human" if species is None else species
-        if filenames:
-            self.filenames = filenames
+        self.filenames = filenames if filenames else None
 
         if database:
             # We don't allow custom databases inside lamindb instances
@@ -89,9 +88,15 @@ class Entity:
     @cached_property
     def df(self) -> pd.DataFrame:
         """DataFrame."""
-        self._filepath = settings.datasetdir / self.filenames.get(
-            f"{self.species}_{self.database}"
-        )
+        if self.filenames:
+            self._filepath = settings.datasetdir / self.filenames.get(
+                f"{self.species}_{self.database}"
+            )
+        else:
+            self._filepath = (
+                settings.datasetdir
+                / f"{self.species}_{self.database}_{self.__class__.__name__}_lookup.parquet"  # noqa: W503,E501
+            )
 
         if not self._filepath.exists():
             df = self._ontology_to_df(self.ontology)

--- a/bionty/_phenotype/_core.py
+++ b/bionty/_phenotype/_core.py
@@ -2,10 +2,6 @@ from typing import Optional
 
 from .._entity import Entity
 
-FILENAMES = {
-    "human_hp": "phenotype_lookup.parquet",
-}
-
 
 class Phenotype(Entity):
     """Phenotype.
@@ -29,5 +25,4 @@ class Phenotype(Entity):
             database=database,
             version=version,
             species=species,
-            filenames=FILENAMES,
         )

--- a/bionty/_tissue/_core.py
+++ b/bionty/_tissue/_core.py
@@ -2,10 +2,6 @@ from typing import Optional
 
 from .._entity import Entity
 
-FILENAMES = {
-    "human_uberon": "human_uberon_lookup.parquet",
-}
-
 
 class Tissue(Entity):
     """Tissue.
@@ -20,4 +16,4 @@ class Tissue(Entity):
         database: Optional[str] = None,
         version: Optional[str] = None,
     ) -> None:
-        super().__init__(id=id, database=database, version=version, filenames=FILENAMES)
+        super().__init__(id=id, database=database, version=version)


### PR DESCRIPTION
Fixes #221 partially

@sunnyosun we could also get rid of the FILENAMES for the Entities that access S3. Then we'd need to standardize the names on S3.

The new standard for the names is:

```
f"{self.species}_{self.database}_{self.__class__.__name__}_lookup.parquet"
```

Is this something that you could take care of?