### PR TITLE
:bug: Fix version order

### DIFF
--- a/bionty/_entity.py
+++ b/bionty/_entity.py
@@ -59,7 +59,8 @@ class Entity:
                     "Check active databases using `bionty.display_active_versions`."
                 )
 
-            database = br.normalize_prefix(database)
+            if br.normalize_prefix(database):
+                database = br.normalize_prefix(database)
         self._set_attributes(database=database, version=version)
 
     @property
@@ -237,7 +238,7 @@ class Entity:
         return settings.dynamicdir / f"{version}___{filename}"
 
     def _load_versions(
-        self, source: Literal["versions", "_local"] = "_local"
+        self, source: Literal["versions", "local"] = "local"
     ) -> Dict[str, Dict[str, Dict]]:
         """Load all versions with string version keys."""
         YAML_PATH = (
@@ -278,7 +279,7 @@ class Entity:
             .items()
         )
 
-        available_db_versions = self._load_versions(source="_local")
+        available_db_versions = self._load_versions(source="local")
 
         # Use the latest version if version is None.
         self._version = current_version if version is None else str(version)

--- a/bionty/dev/_io.py
+++ b/bionty/dev/_io.py
@@ -12,9 +12,11 @@ def load_yaml(filename: Union[str, Path]):  # pragma: no cover
         return yaml.safe_load(f)
 
 
-def write_yaml(data: dict, filename: Union[str, Path]):  # pragma: no cover
+def write_yaml(
+    data: dict, filename: Union[str, Path], sort_keys: bool = False
+):  # pragma: no cover
     with open(filename, "w") as f:
-        yaml.dump(data, f)
+        yaml.dump(data, f, sort_keys=sort_keys)
 
 
 def url_download(  # pragma: no cover

--- a/scripts/check_ontologies_reachable.py
+++ b/scripts/check_ontologies_reachable.py
@@ -51,10 +51,11 @@ versions_only = get_yaml_key_values(VERSIONS_FILE_PATH.resolve(), key="versions"
 failed_urls = []
 for pair in versions_only:
     for url in pair.values():
-        try:
-            assert urllib.request.urlopen(url, timeout=100).getcode() == 200
-        except (AssertionError, ValueError, HTTPError, URLError) as e:
-            failed_urls.append([url, e])
+        if url.startswith("http"):
+            try:
+                assert urllib.request.urlopen(url, timeout=100).getcode() == 200
+            except (AssertionError, ValueError, HTTPError, URLError) as e:
+                failed_urls.append([url, e])
 
 if len(failed_urls) != 0:
     for fail in failed_urls:


### PR DESCRIPTION
Fixes #247 

```
import bionty as bt

ct = bt.CellType()
print(ct.database)
```

now returns 

'cl'

as desired.

The issue was that pyyaml dumps yamls alphabetically ordered by default.