### PR TITLE
🚑 Ensure version names are strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         language_version: python3
         args:
           - --max-line-length=88
-          - --ignore=E203
+          - --ignore=E203,BLK100
           - --min-python-version=3.8.0
         exclude: |
           (?x)(

--- a/bionty/dev/_handle_versions.py
+++ b/bionty/dev/_handle_versions.py
@@ -92,10 +92,11 @@ def create_local(overwrite: bool = True) -> None:
             for db_name, v in dbs.items():
                 # list is needed here to avoid dict key change error
                 for version in list(v["versions"]):
-                    if str(version) != version:
-                        local_versions[entity][db_name]["versions"][
-                            str(version)
-                        ] = local_versions[entity][db_name]["versions"].pop(version)
+                    if isinstance(version, str):
+                        continue
+                    local_versions[entity][db_name]["versions"][
+                        str(version)
+                    ] = local_versions[entity][db_name]["versions"].pop(version)
 
         write_yaml(local_versions, LOCAL_PATH)
 


### PR DESCRIPTION
@Zethson I'm converting version keys to strings when writing local.yaml here, otherwise we'll have type erroring in lamindb.