### PR TITLE
👷 Test against `lnschema-bionty`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
+        package: ["bionty", "lnschema-bionty"]
     timeout-minutes: 25
 
     steps:
       - name: Checkout main
         uses: actions/checkout@v3
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: Checkout lndocs
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           nox -s lint --python ${{ matrix.python-version }}
       - name: Build
         run: |
-          nox -s build --python ${{ matrix.python-version }} --package ${{ matrix.package }}
+          nox -s "build(package='${{ matrix.package }}')" --python ${{ matrix.python-version }}
       - name: Codecov
         if: matrix.python-version == '3.9'
         uses: codecov/codecov-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           nox -s lint --python ${{ matrix.python-version }}
       - name: Build
         run: |
-          nox -s build --python ${{ matrix.python-version }}
+          nox -s build --python ${{ matrix.python-version }} --package ${{ matrix.package }}
       - name: Codecov
         if: matrix.python-version == '3.9'
         uses: codecov/codecov-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           nox -s lint --python ${{ matrix.python-version }}
       - name: Build
         run: |
-          nox -s "build(package='${{ matrix.package }}')" --python ${{ matrix.python-version }}
+          nox -s "build(package='${{ matrix.package }}')"
       - name: Codecov
         if: matrix.python-version == '3.9'
         uses: codecov/codecov-action@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lnschema-bionty"]
+	path = lnschema-bionty
+	url = https://github.com/laminlabs/lnschema-bionty

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ def lint(session: nox.Session) -> None:
     run_pre_commit(session)
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session
 @nox.parametrize("package", ["bionty", "lnschema-bionty"])
 def build(session, package):
     login_testuser1(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,12 @@
 import nox
 from laminci import move_built_docs_to_docs_slash_project_slug, upload_docs_dir
-from laminci.nox import build_docs, login_testuser1, run_pre_commit, run_pytest
+from laminci.nox import (
+    build_docs,
+    login_testuser1,
+    run_pre_commit,
+    run_pytest,
+    setup_test_instances_from_main_branch,
+)
 
 nox.options.reuse_existing_virtualenvs = True
 
@@ -11,10 +17,16 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11"])
-def build(session):
+@nox.parametrize("package", ["bionty", "lnschema-bionty"])
+def build(session, package):
     login_testuser1(session)
+    setup_test_instances_from_main_branch(session)
     session.install(".[dev,test]")
-    run_pytest(session)
-    build_docs(session)
-    upload_docs_dir()
-    move_built_docs_to_docs_slash_project_slug()
+    session.install("./lnschema-bionty[dev,test]")
+    if package == "bionty":
+        run_pytest(session)
+        build_docs(session)
+        upload_docs_dir()
+        move_built_docs_to_docs_slash_project_slug()
+    else:
+        session.run("pytest", "-s", "./lnschema-bionty/tests")


### PR DESCRIPTION
This works except that it doesn't respect the python arg in the nox session anymore - haven't figured out to do this. But Python 3.9 is probably fine here, given we test other versions downstream.