### PR TITLE
🚚 Renamed to reference_id everywhere

### DIFF
--- a/bionty/_entity.py
+++ b/bionty/_entity.py
@@ -39,7 +39,6 @@ class Entity:
         database: Optional[str],
         version: Optional[str] = None,
         species: Optional[str] = None,
-        filenames: Optional[Dict[str, str]] = None,
         *,
         prefix: Optional[str] = None,
         reference_id: Optional[str] = None,
@@ -48,9 +47,8 @@ class Entity:
         # lookup column can be changed using `.lookup_field = `.
         self._lookup_field = "name"
         self._species = "human" if species is None else species
-        self.filenames = filenames if filenames else None
         self.prefix = prefix
-        self.reference_index = "ontology_id" if reference_id is None else reference_id
+        self.reference_id = reference_id
 
         if database:
             # We don't allow custom databases inside lamindb instances
@@ -104,6 +102,7 @@ class Entity:
     @cached_property
     def df(self) -> pd.DataFrame:
         """Pandas DataFrame."""
+        # download
         if not self._local_parquet_path.exists():
             try:
                 self._url_download(self._url)
@@ -117,15 +116,18 @@ class Entity:
                         )
                         os.remove(self._ontology_download_path)
                         self._url_download(self._url)
-
+        # write df to parquet file
         df = self._ontology_to_df(self.ontology)
         df.to_parquet(self._local_parquet_path)
 
-        return (
-            pd.read_parquet(self._local_parquet_path)
-            .reset_index()
-            .set_index(self.reference_index)
-        )
+        # loads the df and set index
+        df = pd.read_parquet(self._local_parquet_path).reset_index()
+        if self.reference_id is None and "ontology_id" in df.columns:
+            self.reference_id = "ontology_id"
+        try:
+            return df.set_index(self.reference_id)
+        except KeyError:
+            return df
 
     @property
     def lookup_field(self) -> str:
@@ -183,7 +185,7 @@ class Entity:
         return list(df[0].values)
 
     def _ontology_to_df(self, ontology: Ontology):
-        """Convert ontology to a DataFrame with id and name columns."""
+        """Convert ontology to a DataFrame with ontology_id and name columns."""
         if self.prefix:
             return pd.DataFrame(
                 [
@@ -192,12 +194,12 @@ class Entity:
                     if term.id.startswith(f"{self.prefix}:")
                 ],
                 columns=["ontology_id", "name"],
-            ).set_index(self.reference_index)
+            ).set_index("ontology_id")
         else:
             return pd.DataFrame(
                 [(term.id, term.name) for term in ontology.terms()],
                 columns=["ontology_id", "name"],
-            ).set_index(self.reference_index)
+            ).set_index("ontology_id")
 
     @check_dynamicdir_exists
     def _url_download(self, url: str):
@@ -292,7 +294,7 @@ class Entity:
         self,
         df: pd.DataFrame,
         column: str = None,
-        reference_index: str = "ontology_id",
+        reference_id: str = "ontology_id",
         case_sensitive: bool = True,
     ) -> pd.DataFrame:
         """Curate index of passed DataFrame to conform with default identifier.
@@ -305,7 +307,7 @@ class Entity:
         Args:
             df: The input Pandas DataFrame to curate.
             column: The column in the passed Pandas DataFrame to curate.
-            reference_index: The reference column in the ontology Pandas DataFrame.
+            reference_id: The reference column in the ontology Pandas DataFrame.
                              'Defaults to ontology_id'.
             case_sensitive: Whether the curation should be case sensitive or not.
                             Defaults to True.
@@ -314,15 +316,17 @@ class Entity:
             Returns the DataFrame with the curated index and a boolean `__curated__`
             column that indicates compliance with the default identifier.
         """
-        if self.reference_index and reference_index != "ontology_id":
-            reference_index = reference_index
-        elif self.reference_index:
-            reference_index = self.reference_index
+        if self.reference_id and reference_id != "ontology_id":
+            reference_id = reference_id
+        elif self.reference_id:
+            reference_id = self.reference_id
+        # this is needed for features parsing in lamindb
+        self._parsing_id = reference_id
 
         df = df.copy()
         orig_column = column
         if column is not None and column not in self.df.columns:
-            column = reference_index
+            column = reference_id
             df.rename(columns={orig_column: column}, inplace=True)
 
         # uppercasing the target column before curating
@@ -336,7 +340,7 @@ class Entity:
                 df.index = df.index.str.upper()
 
         curated_df = self._curate(
-            df=df, column=column, reference_id=reference_index
+            df=df, column=column, reference_id=reference_id
         ).rename(columns={column: orig_column})
 
         # change the original column values back

--- a/bionty/entities/_gene.py
+++ b/bionty/entities/_gene.py
@@ -56,7 +56,7 @@ class Gene(Entity):
         NormalizeColumns.gene(df, species=self.species)
         if not df.index.is_numeric():
             df = df.reset_index().copy()
-        df = df[~df[self.reference_index].isnull()]
+        df = df[~df[self.reference_id].isnull()]
 
         return df
 

--- a/bionty/entities/_protein.py
+++ b/bionty/entities/_protein.py
@@ -50,7 +50,7 @@ class Protein(Entity):
         )  # Take the shortest name in protein names list as name
         if not df.index.is_numeric():
             df = df.reset_index().copy()
-        df = df[~df[self.reference_index].isnull()]
+        df = df[~df[self.reference_id].isnull()]
 
         return df
 

--- a/bionty/entities/_shared_docstrings.py
+++ b/bionty/entities/_shared_docstrings.py
@@ -23,9 +23,7 @@ def remove_prefix(
 
 
 doc_entites = """\
-species: `name` of `Species` entity Entity.
-        id: Field name that should constitute the primary reference for each value.
-            It will also be the primary key in the corresponding SQL Entity.
+species: `name` of `Species` entity.
         database: The key of the database in the local.yml versions file.
                   Get all available databases with `bionty.display_available_versions`.
         version: The version of the ontology. Typically a date or an actual version.

--- a/tests/entities/test_cellline.py
+++ b/tests/entities/test_cellline.py
@@ -32,7 +32,7 @@ def test_clo_cellline_curation_name():
         ]
     )
     curated_df = bt.CellLine(database="clo", version="2022-03-21").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_cellmarker.py
+++ b/tests/entities/test_cellmarker.py
@@ -9,7 +9,7 @@ def test_cellmarker_cellmarker_curation_name_human():
     )
 
     curated_df = bt.CellMarker(database="cellmarker", version="2.0").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
@@ -25,7 +25,7 @@ def test_cellmarker_cellmarker_curation_name_mouse():
 
     curated_df = bt.CellMarker(
         species="mouse", database="cellmarker", version="2.0"
-    ).curate(df, reference_index="name")
+    ).curate(df, reference_id="name")
 
     curation = curated_df["__curated__"].reset_index(drop=True)
     expected_series = pd.Series([True, True, True, True, False])

--- a/tests/entities/test_celltype.py
+++ b/tests/entities/test_celltype.py
@@ -33,7 +33,7 @@ def test_cl_celltype_curation_name():
         ]
     )
     curated_df = bt.CellType(database="cl", version="2022-08-16").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
@@ -72,7 +72,7 @@ def test_ca_celltype_curation_name():
         ]
     )
     curated_df = bt.CellType(database="ca", version="2022-12-16").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_disease.py
+++ b/tests/entities/test_disease.py
@@ -32,7 +32,7 @@ def test_mondo_disease_curation_name():
         ]
     )
     curated_df = bt.Disease(database="mondo", version="2023-02-06").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
@@ -70,7 +70,7 @@ def test_doid_disease_curation_name():
         ]
     )
     curated_df = bt.Disease(database="doid", version="2023-01-30").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_phenotype.py
+++ b/tests/entities/test_phenotype.py
@@ -32,7 +32,7 @@ def test_hp_phenotype_curation_name():
         ]
     )
     curated_df = bt.Phenotype(database="hp", version="2023-01-27").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_protein.py
+++ b/tests/entities/test_protein.py
@@ -32,7 +32,7 @@ def test_uniprot_protein_curation_name():
         ]
     )
     curated_df = bt.Protein(database="uniprot", version="2022-04").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_readout.py
+++ b/tests/entities/test_readout.py
@@ -32,7 +32,7 @@ def test_efo_readout_curation_name():
         ]
     )
     curated_df = bt.Readout(database="efo", version="3.48.0").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_species.py
+++ b/tests/entities/test_species.py
@@ -14,7 +14,7 @@ def test_ensemble_species_curation_ontology_id():
         ]
     )
     curated_df = bt.Species(database="ensembl", version="release-108").curate(
-        df, reference_index="id"
+        df, reference_id="id"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
@@ -34,7 +34,7 @@ def test_ensemble_species_curation_name():
         ]
     )
     curated_df = bt.Species(database="ensembl", version="release-108").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)

--- a/tests/entities/test_tissue.py
+++ b/tests/entities/test_tissue.py
@@ -32,7 +32,7 @@ def test_uberon_tissue_curation_name():
         ]
     )
     curated_df = bt.Tissue(database="uberon", version="2023-02-14").curate(
-        df, reference_index="name"
+        df, reference_id="name"
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)


### PR DESCRIPTION
- Renamed to `reference_id` everywhere to reduce confusion
- Removed `id` from docstring
- Added a private param `._parsing_id` for lamindb feature parsing