### PR TITLE
📌 No pinning of lndb-storage version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pyarrow",
     "nbproject",
     "lndb",
-    "lndb_storage==0.2rc3",
+    "lndb_storage>=0.2rc3",
     "rich",
     "bioregistry"
 ]


### PR DESCRIPTION
lndb-storage should only be pinned in lamindb, otherwise will cause conflicts.