### PR TITLE
✨ Include `synonyms`, `definition` columns in parquet

### DIFF
--- a/bionty/entities/_cellline.py
+++ b/bionty/entities/_cellline.py
@@ -23,4 +23,10 @@ class CellLine(Bionty):
         version: Optional[str] = None,
         **kwargs
     ) -> None:
-        super().__init__(source=source, version=version, species=species, **kwargs)
+        super().__init__(
+            source=source,
+            version=version,
+            species=species,
+            include_id_prefixes={"clo": ["CLO"]},
+            **kwargs
+        )

--- a/bionty/entities/_celltype.py
+++ b/bionty/entities/_celltype.py
@@ -27,4 +27,10 @@ class CellType(Bionty):
         version: Optional[str] = None,
         **kwargs
     ) -> None:
-        super().__init__(source=source, version=version, species=species, **kwargs)
+        super().__init__(
+            source=source,
+            version=version,
+            species=species,
+            include_id_prefixes={"cl": ["CL"]},
+            **kwargs
+        )

--- a/bionty/entities/_disease.py
+++ b/bionty/entities/_disease.py
@@ -31,6 +31,6 @@ class Disease(Bionty):
             source=source,
             version=version,
             species=species,
-            exclude_id_prefixes={"mondo": ["http"]},
+            include_id_prefixes={"mondo": ["MONDO"]},
             **kwargs
         )

--- a/bionty/entities/_drug.py
+++ b/bionty/entities/_drug.py
@@ -27,6 +27,6 @@ class Drug(Bionty):
             source=source,
             version=version,
             species=species,
-            exclude_id_prefixes={"dron": ["SO:", "PR:", "BFO:"]},
+            include_id_prefixes={"dron": ["DRON"]},
             **kwargs
         )

--- a/bionty/entities/_pathway.py
+++ b/bionty/entities/_pathway.py
@@ -20,7 +20,7 @@ class Pathway(Bionty):
         self,
         species: str = "human",
         source: Optional[Literal["pw"]] = None,
-        version: Optional[str] = None,
+        version: Optional[str] = "7.74",  # change to None after fixing 7.78
         **kwargs
     ) -> None:
         super().__init__(source=source, version=version, species=species, **kwargs)

--- a/bionty/entities/_phenotype.py
+++ b/bionty/entities/_phenotype.py
@@ -23,4 +23,10 @@ class Phenotype(Bionty):
         version: Optional[str] = None,
         **kwargs
     ) -> None:
-        super().__init__(source=source, version=version, species=species, **kwargs)
+        super().__init__(
+            source=source,
+            version=version,
+            species=species,
+            include_id_prefixes={"hp": ["HP"]},
+            **kwargs
+        )

--- a/docs/guide/lookup.ipynb
+++ b/docs/guide/lookup.ipynb
@@ -397,7 +397,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/guide/ontology.ipynb
+++ b/docs/guide/ontology.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "053a464e-df2f-4386-b537-4f0a4fb46408",
    "metadata": {},
@@ -21,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fdec8739-4605-4b93-b7f4-be3d7bc22367",
    "metadata": {},
@@ -39,6 +41,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6e33f73d-ea0a-40f8-899d-0451a7d6fc6e",
    "metadata": {},
@@ -57,6 +60,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "da817e13-2102-47af-8d05-da8f1039ec47",
    "metadata": {},
@@ -65,6 +69,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1a61c7de",
    "metadata": {},
@@ -94,6 +99,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6d0b357",
    "metadata": {},
@@ -122,11 +128,42 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ddd6918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookup.astrocyte.definition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4adaa37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookup.astrocyte.synonyms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4e19d23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookup.astrocyte.children"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f6e715d6",
    "metadata": {},
    "source": [
-    "Cell type ontology is accessible via [pronto Ontology](https://pronto.readthedocs.io/en/stable/api/pronto.Ontology.html) as `.ontology`"
+    "[pronto Ontology object](https://pronto.readthedocs.io/en/stable/api/pronto.Ontology.html) is accessible via  as `.ontology`"
    ]
   },
   {
@@ -136,50 +173,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ct.ontology"
+    "pronto_ontology = ct.ontology"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aba7b73c",
+   "id": "3bd888f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(ct.ontology.terms())"
+    "pronto_ontology"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7882d934",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "term = ct.ontology[\"CL:0000128\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1d70db0d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "term.definition"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "63e7b224",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "term.is_leaf()"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2856c9b",
    "metadata": {},
@@ -188,6 +196,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b9872bce-88b0-4118-9579-046e16b7dd1e",
    "metadata": {},
@@ -237,6 +246,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "73b5eab8-f1e5-4bac-9bae-1412be65ba90",
    "metadata": {},
@@ -286,6 +296,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "53364562-b2d5-4fd9-b6ca-3dbfdd4e4b13",
    "metadata": {},
@@ -338,10 +349,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lookup.cerebral_nerve_fasciculus"
+    "lookup.Abnormal_blood_glucose_concentration"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "be4cab83",
    "metadata": {},
@@ -350,18 +362,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "879230a6",
    "metadata": {},
    "source": [
-    "{class}`~bionty.Readout` parses [Experimental Factor Ontology](https://www.ebi.ac.uk/efo/) to the following categories for describing biological experiments:\n",
-    "- efo_id\n",
-    "- name\n",
+    "{class}`~bionty.Readout` parses [Experimental Factor Ontology](https://www.ebi.ac.uk/efo/) to the following additonal categories for describing biological experiments:\n",
     "- molecule\n",
     "- instrument\n",
-    "- measurement\n",
-    "\n",
-    "The columns are reflected in the `readout` table in [lnschema-wetlab](https://lamin.ai/docs/lnschema-wetlab/lnschema_wetlab.readout)."
+    "- measurement"
    ]
   },
   {
@@ -386,41 +395,51 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4891f65b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lookup = readout.lookup()"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "5226036a",
+   "id": "689b1622",
    "metadata": {},
    "source": [
-    "Search for a molecular readout:"
+    "Look up a molecular readout:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8de7f3ff",
+   "id": "6edacdf2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "readout.get(\"EFO:0010891\")"
+    "lookup.single_cell_RNA_sequencing"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
-   "id": "1b3689fa",
+   "id": "9e501882",
    "metadata": {},
    "source": [
-    "Searching for a non-molecular readout:"
+    "Lookup a phenotypic readout:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6924b00c",
-   "metadata": {
-    "tags": []
-   },
+   "id": "449fc7d1",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "readout.get(\"EFO:0004134\")"
+    "lookup.tumor_size"
    ]
   }
  ],

--- a/tests/entities/test_cellline.py
+++ b/tests/entities/test_cellline.py
@@ -6,10 +6,10 @@ import bionty as bt
 def test_clo_cellline_curation_ontology_id():
     df = pd.DataFrame(
         index=[
-            "BFO:0000003",
-            "http://www.ebi.ac.uk/efo/EFO_0002970",
-            "http://www.ebi.ac.uk/efo/EFO_0002970",
-            "BFO:0000004",
+            "CLO:0001210",
+            "CLO:0001230",
+            "CLO:0001248",
+            "CLO:0001225",
             "This cell line does not exist",
         ]
     )
@@ -26,10 +26,10 @@ def test_clo_cellline_curation_ontology_id():
 def test_clo_cellline_curation_name():
     df = pd.DataFrame(
         index=[
-            "DA05702 cell",
-            "DA05703 cell",
-            "immortal astrocyte cell line cell",
-            "15P-1 cell",
+            "253D cell",
+            "HEK293",
+            "2C1H7 cell",
+            "283TAg cell",
             "This cell line does not exist",
         ]
     )

--- a/tests/entities/test_celltype.py
+++ b/tests/entities/test_celltype.py
@@ -6,10 +6,10 @@ import bionty as bt
 def test_cl_celltype_curation_ontology_id():
     df = pd.DataFrame(
         index=[
-            "BFO:0000002",
-            "BFO:0000004",
-            "UBERON:8480008",
-            "UBERON:8480004",
+            "CL:0002084",
+            "CL:0002092",
+            "CL:0002094",
+            "CL:0002079",
             "This cell type does not exist",
         ]
     )
@@ -26,10 +26,10 @@ def test_cl_celltype_curation_ontology_id():
 def test_cl_celltype_curation_name():
     df = pd.DataFrame(
         index=[
-            "placental artery",
-            "placental artery endothelium",
-            "spatial region",
-            "continuant",
+            "Boettcher cell",
+            "bone marrow cell",
+            "interstitial cell of ovary",
+            "pancreatic ductal cell",
             "This cell type does not exist",
         ]
     )

--- a/tests/entities/test_celltype.py
+++ b/tests/entities/test_celltype.py
@@ -77,6 +77,6 @@ def test_ca_celltype_curation_name():
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
-    expected_series = pd.Series([True, True, True, True, False])
+    expected_series = pd.Series([True, True, True, False, False])
 
     assert curation.equals(expected_series)

--- a/tests/entities/test_celltype.py
+++ b/tests/entities/test_celltype.py
@@ -57,7 +57,7 @@ def test_ca_celltype_curation_ontology_id():
     curated_df = bt.CellType(source="ca", version="2022-12-16").curate(df)
 
     curation = curated_df["__curated__"].reset_index(drop=True)
-    expected_series = pd.Series([True, True, True, True, False])
+    expected_series = pd.Series([True, True, True, False, False])
 
     assert curation.equals(expected_series)
 
@@ -77,6 +77,6 @@ def test_ca_celltype_curation_name():
     )
 
     curation = curated_df["__curated__"].reset_index(drop=True)
-    expected_series = pd.Series([True, True, True, False, False])
+    expected_series = pd.Series([True, True, True, True, False])
 
     assert curation.equals(expected_series)

--- a/tests/entities/test_disease.py
+++ b/tests/entities/test_disease.py
@@ -6,10 +6,10 @@ import bionty as bt
 def test_mondo_disease_curation_ontology_id():
     df = pd.DataFrame(
         index=[
-            "UBERON:8440004",
-            "UPHENO:0001001",
-            "UBERON:8420000",
-            "UBERON:8410057",
+            "MONDO:0001724",
+            "MONDO:0001712",
+            "MONDO:0001732",
+            "MONDO:0001735",
             "This disease does not exist",
         ]
     )
@@ -26,10 +26,10 @@ def test_mondo_disease_curation_ontology_id():
 def test_mondo_disease_curation_name():
     df = pd.DataFrame(
         index=[
-            "laminar subdivision of the cortex",
-            "hair of scalp",
-            "laminar subdivision of the cortex",
-            "capillary of anorectum",
+            "supraglottis cancer",
+            "alexia",
+            "trigonitis",
+            "paranasal sinus disorder",
             "This disease does not exist",
         ]
     )

--- a/tests/entities/test_drug.py
+++ b/tests/entities/test_drug.py
@@ -6,10 +6,10 @@ import bionty as bt
 def test_dron_drug_curation_ontology_id():
     df = pd.DataFrame(
         index=[
-            "APOLLO:SV_00000145",
-            "APOLLO:SV_00000336",
-            "CHEBI:100147",
-            "CHEBI:10023",
+            "DRON:00018440",
+            "DRON:00018432",
+            "DRON:00018438",
+            "DRON:00018452",
             "This drug does not exist",
         ]
     )
@@ -25,10 +25,10 @@ def test_dron_drug_curation_ontology_id():
 def test_dron_drug_curation_name():
     df = pd.DataFrame(
         index=[
-            "resistance to infection",
-            "resistance to malaria infection",
-            "voriconazole",
-            "nalidixic acid",
+            "LILIUM LONGIFLORIUM",
+            "citrus bioflavonoids",
+            "Ornithine, (L)-Isomer",
+            "Hyoscyamus extract",
             "This disease does not exist",
         ]
     )

--- a/tests/entities/test_phenotype.py
+++ b/tests/entities/test_phenotype.py
@@ -6,10 +6,10 @@ import bionty as bt
 def test_hp_phenotype_curation_ontology_id():
     df = pd.DataFrame(
         index=[
-            "BFO:0000001",
-            "HGNC:9958",
-            "HGNC:8582",
-            "BFO:0000006",
+            "HP:0001328",
+            "HP:0001332",
+            "HP:0001342",
+            "HP:0001350",
             "This phenotype does not exist",
         ]
     )
@@ -26,10 +26,10 @@ def test_hp_phenotype_curation_ontology_id():
 def test_hp_phenotype_curation_name():
     df = pd.DataFrame(
         index=[
-            "eukaryotic protein",
-            "Fixated interest with abnormal intensity",
-            "Hand-leading gestures",
-            "Idiosyncratic language",
+            "Specific learning disability",
+            "Dystonia",
+            "Cerebral hemorrhage",
+            "Slurred speech",
             "This phenotype does not exist",
         ]
     )


### PR DESCRIPTION
- Parsed synonyms, definition from ontology file and saved to parquet columns
- Parsed out instrument, molecule, measurement for EFO Readout and saved to parquet (Readout class finally behaves the same as other classes), changed `.get` to `._parse`.
- Specified prefix for all ontologies to be itself
- Updated all parquet files on S3

Note:
Temporarily default Pathway version to `7.74` due to this error: https://github.com/laminlabs/bionty/issues/371