### PR TITLE
🐛 Fix LAMINDB_INSTANCE_LOADED on Windows

### DIFF
--- a/bionty/dev/_handle_sources.py
+++ b/bionty/dev/_handle_sources.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Dict, List, Literal, Union
 
@@ -18,9 +17,7 @@ LAMINDB_SOURCES = ROOT / ".lamindb_current_sources.yaml"
 # Visible to the users and can be modified
 LOCAL_SOURCES = settings.versionsdir / "sources.local.yaml"
 
-LAMINDB_INSTANCE_LOADED = os.path.exists(
-    f"{os.environ['HOME']}/.lamin/current_instance.env"
-)
+LAMINDB_INSTANCE_LOADED = (Path.home() / ".lamin/current_instance.env").exists()
 
 
 def parse_sources_yaml(filepath: Union[str, Path]) -> DataFrame:


### PR DESCRIPTION
There is no `os.environ["HOME"]` on Windows.