### PR TITLE
🎨 Default to name field for map_synonyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ lookup_dict = lookup.dict()
 lookup_dict["single-cell RNA sequencing"]
 ```
 
-## Inspect & map identifiers
+## Search ontology terms
+
+```python
+import bionty as bt
+
+celltype_bionty = bt.CellType()
+# Free text search against a field
+celltype_bionty.search("gamma delta T cell")
+```
+
+## Inspect & standardize identifiers
 
 ```python
 import bionty as bt
@@ -59,11 +69,7 @@ gene_bionty = bt.Gene()
 # Inspect if the gene symbols are mappable onto the reference
 gene_bionty.inspect(["A1BG", "FANCD1"], gene_bionty.symbol)
 # Map synonyms of gene symbols
-gene_bionty.map_synonyms(["A1BG", "FANCD1"], gene_bionty.symbol)
-
-celltype_bionty = bt.CellType()
-# Free text search against a field
-celltype_bionty.search("gamma delta T cell", celltype_bionty.name)
+gene_bionty.map_synonyms(["A1BG", "FANCD1"])
 ```
 
 ## Reference tables of ontologies

--- a/bionty/_bionty.py
+++ b/bionty/_bionty.py
@@ -46,11 +46,14 @@ class Bionty:
             logger.error(
                 f"Only default sources below are allowed inside LaminDB instances!\n{self._default_sources}\n"  # noqa: E501
             )
+            # fmt: off
             logger.hint(
-                "To use a different source, please either:\n    Close your instance"
-                " via `lamin close` \n    OR\n    Configure currently_used"
-                f" {self.__class__.__name__} source in lnschema_bionty.BiontySource"
+                f"To use a different source, please either:\n"
+                f"    Close your instance via `lamin close`\n"
+                f"    OR\n"
+                f"    Configure currently_used {self.__class__.__name__} source in `lnschema_bionty.BiontySource`"
             )
+            # fmt: on
             self._source = None  # type: ignore
             return
 
@@ -327,21 +330,22 @@ class Bionty:
         """Inspect if a list of identifiers are mappable to the entity reference.
 
         Args:
-            identifiers: Identifiers that will be checked against the Ontology.
+            identifiers: Identifiers that will be checked against the field.
             field: The BiontyField of the ontology to compare against.
                           Examples are 'ontology_id' to map against the ontology ID
                           or 'name' to map against the ontologies field names.
             return_df: Whether to return a Pandas DataFrame.
 
         Returns:
-            - A Dictionary that maps the input ontology (keys) to the ontology field (values)
-            - If specified A Pandas DataFrame with the curated index and a boolean `__mapped__`
-              column that indicates compliance with the default identifier.
+            - A Dictionary of "mapped" and "unmapped" identifiers
+            - If `return_df`: A DataFrame indexed by identifiers with a boolean `__mapped__`
+              column that indicates compliance with the identifiers.
 
         Examples:
             >>> import bionty as bt
-            >>> celltype_bionty = bt.CellType()
-            >>> celltype_bionty.inspect(["Boettcher cell", "bone marrow cell"], field=celltype_bionty.name)
+            >>> gene_bionty = bt.Gene()
+            >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
+            >>> gene_bionty.inspect(gene_symbols, field=gene_bionty.symbol)
         """
         mapped_df = pd.DataFrame(index=identifiers)
 
@@ -402,7 +406,7 @@ class Bionty:
         synonyms_sep: str = "|",
         field: Optional[Union[BiontyField, str]] = None,
     ) -> Union[Dict[str, str], List[str]]:
-        """Maps input identifiers against Ontology synonyms.
+        """Maps input identifiers against synonyms.
 
         Args:
             identifiers: Identifiers that will be mapped against an Ontology field (BiontyField).
@@ -420,7 +424,7 @@ class Bionty:
             >>> import bionty as bt
             >>> gene_bionty = bt.Gene()
             >>> gene_symbols = ["A1CF", "A1BG", "FANCD1", "FANCD20"]
-            >>> mapping = gene_bionty.map_synonyms(gene_symbols, gn.symbol)
+            >>> standardized_symbols = gene_bionty.map_synonyms(gene_symbols, gn.symbol)
         """
         from lamin_logger._map_synonyms import map_synonyms
 
@@ -434,7 +438,7 @@ class Bionty:
         )
 
     def lookup(self, field: Optional[Union[BiontyField, str]] = None) -> Tuple:
-        """Return an auto-complete object for the Bionty field.
+        """An auto-complete object for a Bionty field.
 
         Args:
             field: The field to lookup the values for.
@@ -445,10 +449,10 @@ class Bionty:
 
         Examples:
             >>> import bionty as bt
-            >>> lookup = bt.Gene().lookup()
-            >>> lookup.adgb_dt
+            >>> lookup = bt.CellType().lookup()
+            >>> lookup.cd103_positive_dendritic_cell
             >>> lookup_dict = lookup.dict()
-            >>> lookup['ADGB-DT']
+            >>> lookup['CD103-positive dendritic cell']
         """
         return Lookup(
             df=self._df,

--- a/bionty/entities/_cellmarker.py
+++ b/bionty/entities/_cellmarker.py
@@ -1,7 +1,5 @@
 from typing import Literal, Optional
 
-import pandas as pd
-
 from .._bionty import Bionty
 from ._shared_docstrings import _doc_params, doc_entites
 
@@ -26,27 +24,3 @@ class CellMarker(Bionty):
         **kwargs
     ) -> None:
         super().__init__(source=source, version=version, species=species, **kwargs)
-
-    def _load_df(self) -> pd.DataFrame:
-        """DataFrame.
-
-        See ingestion: https://lamin.ai/docs/bionty-assets/ingest/cell-marker-2.0
-        """
-        df = super()._load_df()
-
-        # TODO: remove after updating to new version
-        df = df.drop(columns=["id", "version"], errors="ignore")
-
-        return df
-
-    def df(self) -> pd.DataFrame:
-        """Pandas DataFrame of the ontology.
-
-        Returns:
-            A Pandas DataFrame of the ontology.
-
-        Examples:
-            >>> import bionty as bt
-            >>> bt.CellMarker().df()
-        """
-        return self._df.set_index("name")

--- a/bionty/entities/_gene.py
+++ b/bionty/entities/_gene.py
@@ -1,8 +1,6 @@
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal, Optional
 
-import pandas as pd
-
-from .._bionty import Bionty, BiontyField
+from .._bionty import Bionty
 from ._shared_docstrings import _doc_params, doc_entites
 
 
@@ -34,54 +32,4 @@ class Gene(Bionty):
             version=version,
             species=species,
             **kwargs,
-        )
-
-    def lookup(self, field: Union[BiontyField, str] = "symbol") -> Tuple:
-        """Return an auto-complete object for the bionty field.
-
-        Args:
-            field: The field to lookup the values for.
-                   Defaults to 'name'.
-
-        Returns:
-            A NamedTuple of lookup information of the field values.
-
-        Examples:
-            >>> import bionty as bt
-            >>> gene_lookout = bt.Gene().lookup()
-            >>> gene_lookout.TEF
-        """
-        return super().lookup(field=field)
-
-    def search(
-        self,
-        string: str,
-        field: Union[BiontyField, str] = "symbol",
-        synonyms_field: Union[BiontyField, str, None] = "synonyms",
-        case_sensitive: bool = True,
-        return_ranked_results: bool = False,
-    ) -> pd.DataFrame:
-        """Fuzzy matching of a given string against a Bionty field.
-
-        Args:
-            string: The input string to match against the field ontology values.
-            field: The BiontyField of ontology the input string is matching against.
-            synonyms_field: Also map against in the synonyms (If None, no mapping against synonyms).
-            case_sensitive: Whether the match is case sensitive.
-            return_ranked_results: Whether to return all entries ranked by matching ratios.
-
-        Returns:
-            Best match of the input string.
-
-        Examples:
-            >>> import bionty as bt
-            >>> celltype_bionty = bt.CellType()
-            >>> celltype_bionty.search("gamma delta T cell", celltype_bionty.name)
-        """
-        return super().search(
-            string=string,
-            field=field,
-            synonyms_field=synonyms_field,
-            case_sensitive=case_sensitive,
-            return_ranked_results=return_ranked_results,
         )

--- a/bionty/entities/_readout.py
+++ b/bionty/entities/_readout.py
@@ -8,7 +8,6 @@ from bionty.entities._shared_docstrings import _doc_params, species_removed
 
 from .._bionty import Bionty
 from .._ontology import Ontology
-from ..dev._io import s3_bionty_assets
 
 
 @_doc_params(doc_entities=species_removed)
@@ -31,14 +30,6 @@ class Readout(Bionty):
         version: Optional[str] = None,
         **kwargs,
     ) -> None:
-        self._prefix = "http://www.ebi.ac.uk/efo/"
-        self._readout_terms = {
-            "assay": "OBI:0000070",
-            "assay_by_molecule": "EFO:0002772",
-            "assay_by_instrument": "EFO:0002773",
-            "assay_by_sequencer": "EFO:0003740",
-            "measurement": "EFO:0001444",
-        }
         super().__init__(
             source=source,
             version=version,
@@ -57,96 +48,92 @@ class Readout(Bionty):
             url=self._url,
             md5=self._md5,
         )
-        return Ontology(handle=self._local_ontology_path, prefix=self._prefix)
+        onto = Ontology(
+            handle=self._local_ontology_path, prefix="http://www.ebi.ac.uk/efo/"
+        )
+        onto.__setattr__("efo_to_df", efo_to_df)
+        return onto
 
-    def _load_df(self) -> pd.DataFrame:
-        # Extra parsing steps for EFO ontology
-        if self.source == "efo":
-            # Download and sync from s3://bionty-assets
-            s3_bionty_assets(
-                filename=self._parquet_filename,
-                assets_base_url="s3://bionty-assets",
-                localpath=self._local_parquet_path,
-            )
-            # If download is not possible, write a parquet file from ontology
-            if not self._local_parquet_path.exists():
-                # write df to parquet file
-                df = self.ontology.to_df(
-                    source=self.source, include_id_prefixes=self.include_id_prefixes
-                ).reset_index()
-                # fix ontology_id before saving to parquet
-                df["ontology_id"] = [
-                    i.replace(self._prefix, "").replace("_", ":")
-                    for i in df["ontology_id"]
-                ]
-                df["children"] = [
-                    [j.replace(self._prefix, "").replace("_", ":") for j in i]
-                    for i in df["children"]
-                ]
-                # parse terms
-                logger.info("Parsing EFO terms for the first time will take 6-10min...")
-                parsed_results = []
-                for term in df["ontology_id"]:
-                    parsed_results.append(self._parse(term))
-                df_parsed = pd.DataFrame.from_records(parsed_results)
-                df = df.merge(df_parsed).set_index("ontology_id")
 
-                df.to_parquet(self._local_parquet_path)
+def _parse_efo_term(
+    term_id: str,
+    ontology: Ontology,
+) -> dict:
+    """Parse readout attributes from EFO."""
+    readout_terms = {
+        "assay": "OBI:0000070",
+        "assay_by_molecule": "EFO:0002772",
+        "assay_by_instrument": "EFO:0002773",
+        "assay_by_sequencer": "EFO:0003740",
+        "measurement": "EFO:0001444",
+    }
 
-            # loads the df and set index
-            return pd.read_parquet(self._local_parquet_path)
+    def _list_to_str(lst: list):
+        if len(lst) == 0:
+            return None
+        elif len(lst) == 1:
+            return lst[0].name  # type: ignore
         else:
-            return super()._load_df()
+            return ";".join([i.name for i in lst])
 
-    def _parse(self, term_id: str) -> dict:
-        """Parse readout attributes from EFO."""
+    def _list_subclasses(ontology: Ontology, term, *, distance=1, with_self=False):
+        """Subclasses of a term."""
+        termclass = ontology.get_term(term)
+        return list(termclass.subclasses(distance=distance, with_self=with_self))
 
-        def _list_to_str(lst: list):
-            if len(lst) == 0:
-                return None
-            elif len(lst) == 1:
-                return lst[0].name  # type: ignore
-            else:
-                return ";".join([i.name for i in lst])
+    term = ontology.get_term(term_id)
+    superclasses = term.superclasses()
 
-        def _list_subclasses(ontology: Ontology, term, *, distance=1, with_self=False):
-            """Subclasses of a term."""
-            termclass = ontology.get_term(term)
-            return list(termclass.subclasses(distance=distance, with_self=with_self))
+    # assay = self.ontology._list_subclasses(self._readout_terms["assay"])
+    assay_by_molecule = _list_subclasses(ontology, readout_terms["assay_by_molecule"])
+    assay_by_instrument = _list_subclasses(
+        ontology, readout_terms["assay_by_instrument"]
+    )
 
-        term = self.ontology.get_term(term_id)
-        superclasses = term.superclasses()
+    assay_by_sequencer = _list_subclasses(ontology, readout_terms["assay_by_sequencer"])
+    measurement = _list_subclasses(ontology, readout_terms["measurement"])
 
-        # assay = self.ontology._list_subclasses(self._readout_terms["assay"])
-        assay_by_molecule = _list_subclasses(
-            self.ontology, self._readout_terms["assay_by_molecule"]
-        )
-        assay_by_instrument = _list_subclasses(
-            self.ontology, self._readout_terms["assay_by_instrument"]
-        )
+    # get the molecule term
+    molecules = [i for i in assay_by_molecule if i in superclasses]
+    # get the instrument term
+    instruments = [i for i in assay_by_sequencer if i in superclasses]
+    if len(instruments) == 0:
+        instruments = [i for i in assay_by_instrument if i in superclasses]
+    # get the measurement for non-molecular readouts
+    measurements = [i for i in measurement if i in superclasses]
 
-        assay_by_sequencer = _list_subclasses(
-            self.ontology, self._readout_terms["assay_by_sequencer"]
-        )
-        measurement = _list_subclasses(
-            self.ontology, self._readout_terms["measurement"]
-        )
+    readout = {
+        "ontology_id": term_id,
+        "name": term.name,
+        "molecule": _list_to_str(molecules),
+        "instrument": _list_to_str(instruments),
+        "measurement": _list_to_str(measurements),
+    }
 
-        # get the molecule term
-        molecules = [i for i in assay_by_molecule if i in superclasses]
-        # get the instrument term
-        instruments = [i for i in assay_by_sequencer if i in superclasses]
-        if len(instruments) == 0:
-            instruments = [i for i in assay_by_instrument if i in superclasses]
-        # get the measurement for non-molecular readouts
-        measurements = [i for i in measurement if i in superclasses]
+    return readout
 
-        readout = {
-            "ontology_id": term_id,
-            "name": term.name,
-            "molecule": _list_to_str(molecules),
-            "instrument": _list_to_str(instruments),
-            "measurement": _list_to_str(measurements),
-        }
 
-        return readout
+def efo_to_df(
+    ontology: Ontology,
+    source: str,
+    include_id_prefixes: dict,
+    prefix: str = "http://www.ebi.ac.uk/efo/",
+) -> pd.DataFrame:  # pragma: no cover
+    df = ontology.to_df(
+        source=source, include_id_prefixes=include_id_prefixes
+    ).reset_index()
+    # fix ontology_id before saving to parquet
+    df["ontology_id"] = [
+        i.replace(prefix, "").replace("_", ":") for i in df["ontology_id"]
+    ]
+    df["children"] = [
+        [j.replace(prefix, "").replace("_", ":") for j in i] for i in df["children"]
+    ]
+    # parse terms
+    logger.info("Parsing EFO terms for the first time will take 6-10min...")
+    parsed_results = []
+    for term in df["ontology_id"]:
+        parsed_results.append(_parse_efo_term(term, ontology))
+    df_parsed = pd.DataFrame.from_records(parsed_results)
+    df = df.merge(df_parsed).set_index("ontology_id")
+    return df

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -7,7 +7,7 @@
 :maxdepth: 2
 :hidden:
 
-lookup
+search
 ontology
 inspect
 sources

--- a/docs/guide/inspect.ipynb
+++ b/docs/guide/inspect.ipynb
@@ -17,10 +17,10 @@
     "\n",
     "Bionty enables this by mapping metadata on the versioned ontologies using {meth}`~bionty.Bionty.inspect`.\n",
     "\n",
-    "For terms that are not directly mappable, we offer (also see {doc}`/lookup`):\n",
-    "- {meth}`~bionty.Bionty.map_synonyms`.\n",
-    "- {meth}`~bionty.Bionty.lookup`.\n",
-    "- {meth}`~bionty.Bionty.search`."
+    "For terms that are not directly mappable, we offer (also see {doc}`/search`):\n",
+    "- {meth}`~bionty.Bionty.map_synonyms`\n",
+    "- {meth}`~bionty.Bionty.lookup`\n",
+    "- {meth}`~bionty.Bionty.search`"
    ]
   },
   {
@@ -160,9 +160,7 @@
    },
    "outputs": [],
    "source": [
-    "mapped_symbol_synonyms = gene_bionty.map_synonyms(\n",
-    "    df_orig[\"gene symbol\"], gene_bionty.symbol\n",
-    ")\n",
+    "mapped_symbol_synonyms = gene_bionty.map_synonyms(df_orig[\"gene symbol\"])\n",
     "\n",
     "mapped_symbol_synonyms"
    ]
@@ -181,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gene_bionty.map_synonyms(df_orig[\"gene symbol\"], gene_bionty.symbol, return_mapper=True)"
+    "gene_bionty.map_synonyms(df_orig[\"gene symbol\"], return_mapper=True)"
    ]
   },
   {
@@ -346,9 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "synonyms_mapper = cellmarker_bionty.map_synonyms(\n",
-    "    markers.index, cellmarker_bionty.name, return_mapper=True\n",
-    ")"
+    "synonyms_mapper = cellmarker_bionty.map_synonyms(markers.index, return_mapper=True)"
    ]
   },
   {
@@ -356,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we mapped 3 additional terms:"
+    "Now we mapped 2 additional terms:"
    ]
   },
   {
@@ -479,7 +475,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cellmarker_bionty.search(\"CD127a\", return_ranked_results=True).head(5)"
+    "cellmarker_bionty.search(\"CD127a\").head()"
    ]
   },
   {

--- a/docs/guide/search.ipynb
+++ b/docs/guide/search.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Look up records of Bionty entities"
+    "# Search & lookup terms"
    ]
   },
   {
@@ -274,7 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"cytotoxic T cells\")"
+    "celltype_bionty.search(\"cytotoxic T cells\").head(2)"
    ]
   },
   {
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"P cell\")"
+    "celltype_bionty.search(\"P cell\").head(2)"
    ]
   },
   {
@@ -308,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"P cell\", synonyms_field=None)"
+    "celltype_bionty.search(\"P cell\", synonyms_field=None).head(2)"
    ]
   },
   {
@@ -325,7 +325,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"CD8+ alpha beta T cells\", field=celltype_bionty.definition)"
+    "celltype_bionty.search(\n",
+    "    \"CD8+ alpha beta T cells\", field=celltype_bionty.definition\n",
+    ").head(2)"
    ]
   },
   {
@@ -342,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"P cell\", return_ranked_results=True).head()"
+    "celltype_bionty.search(\"P cell\", top_hit=True)"
    ]
   },
   {
@@ -350,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Tied results will all be returns:"
+    "Tied results will all be returns as top hits:"
    ]
   },
   {
@@ -359,7 +361,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bionty.search(\"A cell\", synonyms_field=None)"
+    "celltype_bionty.search(\"A cell\", top_hit=True, synonyms_field=None)"
    ]
   }
  ],

--- a/tests/entities/test_cellmarker.py
+++ b/tests/entities/test_cellmarker.py
@@ -5,21 +5,21 @@ import bionty as bt
 
 def test_cellmarker_cellmarker_inspect_name_human():
     df = pd.DataFrame(
-        index=["CCR7", "CD69", "CD8A", "CD45RA", "This protein does not exist"]
+        index=["CCR7", "CD69", "CD8", "CD45RA", "This protein does not exist"]
     )
 
     cm = bt.CellMarker(source="cellmarker", version="2.0")
     curated = cm.inspect(df.index, field=cm.name)
 
     assert curated == {
-        "mapped": ["CCR7", "CD69", "CD8A", "CD45RA"],
+        "mapped": ["CCR7", "CD69", "CD8", "CD45RA"],
         "not_mapped": ["This protein does not exist"],
     }
 
 
 def test_cellmarker_cellmarker_inspect_name_mouse():
     df = pd.DataFrame(
-        index=["Tcf4", "Cd36", "Cd34", "Cd45", "This protein does not exist"]
+        index=["Tcf4", "Cd36", "Cd34", "Lgr6", "This protein does not exist"]
     )
 
     cm = bt.CellMarker(source="cellmarker", version="2.0", species="mouse")

--- a/tests/entities/test_readout.py
+++ b/tests/entities/test_readout.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 import bionty as bt
+from bionty.entities._readout import _parse_efo_term
 
 
 def test_efo_readout_inspect_ontology_id():
@@ -23,10 +24,12 @@ def test_efo_readout_inspect_ontology_id():
     assert inspect.equals(expected_series)
 
 
-def test_readout_parse():
+def test_parse_efo_term():
     ro = bt.Readout(source="efo", version="3.48.0")
+    ontology = ro.ontology
+    res = _parse_efo_term(term_id="EFO:0008913", ontology=ontology)
 
-    assert ro._parse("EFO:0008913") == {
+    assert res == {
         "ontology_id": "EFO:0008913",
         "name": "single-cell RNA sequencing",
         "molecule": "RNA assay",


### PR DESCRIPTION
- Only `inspect` now has a required `field` param
- Change `return_ranked_results` to `top_hits` in `.search()`, default to return all results
- Removed redundant code for Gene, Protein, CellMarker