### PR TITLE
🔥 Remove top_hit from search

### DIFF
--- a/bionty/_bionty.py
+++ b/bionty/_bionty.py
@@ -467,7 +467,7 @@ class Bionty:
         string: str,
         *,
         field: Optional[Union[BiontyField, str]] = None,
-        top_hit: bool = False,
+        limit: Optional[int] = None,
         case_sensitive: bool = False,
         synonyms_field: Union[BiontyField, str, None] = "synonyms",
     ) -> pd.DataFrame:
@@ -495,10 +495,9 @@ class Bionty:
             df=self._df,
             string=string,
             field=self._get_default_field(field),
-            return_ranked_results=not top_hit,
+            limit=limit,
             case_sensitive=case_sensitive,
             synonyms_field=str(synonyms_field),
-            tuple_name=self.__class__.__name__,
         )
 
 

--- a/docs/guide/search.ipynb
+++ b/docs/guide/search.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -32,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,6 +62,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -77,6 +81,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -104,6 +109,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -122,6 +128,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -129,6 +136,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -145,6 +153,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -161,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -186,6 +196,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,6 +217,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -240,6 +252,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -256,15 +269,24 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Matching scores are stored in the `__ratio__` column:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bt.search(\"cytotoxic T cells\").head(2)"
+    "celltype_bt.search(\"cytotoxic T cells\").head(3)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,10 +299,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bt.search(\"P cell\").head(2)"
+    "celltype_bt.search(\"P cell\").head(3)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -293,10 +316,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bt.search(\"P cell\", synonyms_field=None).head(2)"
+    "celltype_bt.search(\"P cell\", synonyms_field=None).head(3)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -309,39 +333,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "celltype_bt.search(\"CD8+ alpha beta T cells\", field=celltype_bt.definition).head(2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Return all results as a DataFrame ranked by matching ratios:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "celltype_bt.search(\"P cell\", top_hit=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Tied results will all be returns as top hits:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "celltype_bt.search(\"A cell\", top_hit=True, synonyms_field=None)"
+    "celltype_bt.search(\"CD8 postive alpha beta T cells\", field=celltype_bt.definition).head(\n",
+    "    3\n",
+    ")"
    ]
   }
  ],
@@ -367,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.9.16"
   },
   "vscode": {
    "interpreter": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "pronto>=2.5.4",
-    "lamin_logger>=0.7.6", # don't pin here as it's pinned in lamindb
+    "lamin_logger>=0.8.0", # don't pin here as it's pinned in lamindb
     "pyyaml",
     "pandas",
     "pyarrow",


### PR DESCRIPTION
Removed top_hit from search, always returns df. Pass `limit=` to speed up search.