### PR TITLE
Switch to uv for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           python -m pip install -U pip uv
           uv pip install --system coverage[toml]
-          uv pip install --system --no-deps "bionty-base @ ."
+          uv pip install --system --no-deps ."
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           path: lndocs
           ref: main
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pre-commit
@@ -47,9 +47,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip uv
-          python -m uv pip install -U laminci
-          python -m uv pip install rich
-          python -m uv pip install ipywidgets
+          python -m uv pip install --system -U laminci
+          python -m uv pip install --system rich
+          python -m uv pip install --system ipywidgets
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         group: ["bionty-unit", "bionty-docs"]
     timeout-minutes: 25
 
@@ -47,9 +47,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip uv
-          uv pip install -U laminci
-          uv pip install rich
-          uv pip install ipywidgets
+          python -m uv pip install -U laminci
+          python -m uv pip install rich
+          python -m uv pip install ipywidgets
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
@@ -59,7 +59,7 @@ jobs:
           aws-region: eu-central-1
 
       - name: Lint
-        if: matrix.python-version == '3.10' && matrix.group == 'bionty-unit'
+        if: matrix.python-version == '3.11' && matrix.group == 'bionty-unit'
         run: |
           nox -s lint
       - name: Build
@@ -73,7 +73,7 @@ jobs:
           path: .coverage
 
       - name: Deploy docs
-        if: ${{ matrix.python-version == '3.10' && matrix.group == 'bionty-docs' }}
+        if: ${{ matrix.python-version == '3.11' && matrix.group == 'bionty-docs' }}
         id: netlify
         uses: nwtgck/actions-netlify@v1.2
         with:
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: |
           uv pip install coverage[toml]
           uv pip install --no-deps @ .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           python -m pip install -U pip uv
           uv pip install --system coverage[toml]
-          uv pip install --system --no-deps "bionty @ ."
+          uv pip install --system --no-deps "bionty-base @ ."
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: |
+          python -m pip install -U pip uv
           uv pip install --system coverage[toml]
           uv pip install --system --no-deps @ .
       - uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           python -m pip install -U pip uv
           uv pip install --system coverage[toml]
-          uv pip install --system --no-deps @ .
+          uv pip install --system --no-deps .
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,8 @@ jobs:
         with:
           python-version: "3.11"
       - run: |
-          uv pip install coverage[toml]
-          uv pip install --no-deps @ .
+          uv pip install --system coverage[toml]
+          uv pip install --system --no-deps @ .
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: ".github/workflows/build.yml" # See dependencies below
       - name: Cache pre-commit
         uses: actions/cache@v3
         with:
@@ -48,10 +46,10 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip
-          pip install -U laminci
-          pip install rich
-          pip install ipywidgets
+          python -m pip install -U pip uv
+          uv pip install -U laminci
+          uv pip install rich
+          uv pip install ipywidgets
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
@@ -95,11 +93,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: ".github/workflows/build.yml"
       - run: |
-          pip install coverage[toml]
-          pip install --no-deps .
+          uv pip install coverage[toml]
+          uv pip install --no-deps @ .
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           python -m pip install -U pip uv
           uv pip install --system coverage[toml]
-          uv pip install --system --no-deps ."
+          uv pip install --system --no-deps .
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - run: |
           python -m pip install -U pip uv
           uv pip install --system coverage[toml]
-          uv pip install --system --no-deps .
+          uv pip install --system --no-deps "bionty @ ."
       - uses: actions/download-artifact@v2
       - name: run coverage
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def docs(session: nox.Session):
 @nox.session
 @nox.parametrize("group", ["bionty-unit", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    session.run(*"uv pip install --system -e .".split())
+    session.run(*"uv pip install --system bionty[dev] @ .".split())
     coverage_args = "--cov=bionty_base --cov-append --cov-report=term-missing"
     if group == "bionty-unit":
         session.run(*f"pytest {coverage_args} ./tests".split())

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def docs(session: nox.Session):
 @nox.session
 @nox.parametrize("group", ["bionty-unit", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    session.run(*"uv pip install --system bionty[dev] @ .".split())
+    session.run(*"uv pip install --system -e .[dev]".split())
     coverage_args = "--cov=bionty_base --cov-append --cov-report=term-missing"
     if group == "bionty-unit":
         session.run(*f"pytest {coverage_args} ./tests".split())

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def docs(session: nox.Session):
 @nox.session
 @nox.parametrize("group", ["bionty-unit", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    session.run(*"pip install -e .[dev]".split())
+    session.run(*"uv pip install -e 'bionty[dev] @ .'".split())
     coverage_args = "--cov=bionty_base --cov-append --cov-report=term-missing"
     if group == "bionty-unit":
         session.run(*f"pytest {coverage_args} ./tests".split())

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def docs(session: nox.Session):
 @nox.session
 @nox.parametrize("group", ["bionty-unit", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    session.run(*"uv pip install -e 'bionty[dev] @ .'".split())
+    session.run(*"uv pip install -e bionty[dev] @ .".split())
     coverage_args = "--cov=bionty_base --cov-append --cov-report=term-missing"
     if group == "bionty-unit":
         session.run(*f"pytest {coverage_args} ./tests".split())

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def docs(session: nox.Session):
 @nox.session
 @nox.parametrize("group", ["bionty-unit", "bionty-docs"])
 def build(session: nox.Session, group: str):
-    session.run(*"uv pip install -e bionty[dev] @ .".split())
+    session.run(*"uv pip install --system -e .".split())
     coverage_args = "--cov=bionty_base --cov-append --cov-report=term-missing"
     if group == "bionty-unit":
         session.run(*f"pytest {coverage_args} ./tests".split())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "pronto>=2.5.4, <2.5.6",


### PR DESCRIPTION
https://github.com/actions/setup-python/issues/822

Caching may or may not be a good idea.

On the usage of `--system`:

> For convenience, uv pip install --system will install into the system Python environment, as an approximate shorthand for, e.g., uv pip install --python=$(which python3). Though we generally recommend the use of virtual environments for dependency management, --system is intended to enable the use of uv in continuous integration and containerized environments.

Save us like 30-40 seconds